### PR TITLE
fix: evict dead vCenter sessions - probe handler could never run

### DIFF
--- a/tests/test_hub_routing.py
+++ b/tests/test_hub_routing.py
@@ -1,0 +1,104 @@
+"""Component 6 routing tests for vmware-aiops ConnectionManager.connect().
+
+Exercises the per-role routing path without touching pyVmomi, 1Password, the
+MCP request context, or a real vCenter: _create_connection is replaced with a
+fake that records the creds it was handed, and the uaa_hub_routing entry points
+are monkeypatched. Mirrors the veeam/a10 resolver tests; vmware fronts the PROD
+vCenter (backend `vcenter-prod`), syseng-only. aiops is write-capable, so the
+fail-closed guarantee matters most here.
+"""
+import pytest
+
+# Installed on the hub, not a PyPI dep -> CI without it skips (module import-guards it).
+uaa_hub_routing = pytest.importorskip("uaa_hub_routing")
+
+from vmware_aiops import connection as conn_mod
+from vmware_aiops.config import AppConfig, TargetConfig
+
+
+class _Sess:
+    currentSession = object()
+
+
+class _Content:
+    sessionManager = _Sess()
+
+
+class FakeSI:
+    """Fake ServiceInstance: records creds, satisfies the liveness probe."""
+    def __init__(self, user, pwd):
+        self.user = user
+        self.pwd = pwd
+        self.content = _Content()
+
+
+@pytest.fixture
+def cm(monkeypatch):
+    target = TargetConfig(name="prod", host="vc.example", username="startup-user", verify_ssl=False)
+    cfg = AppConfig(targets=(target,))
+
+    def fake_create(t, *, user=None, pwd=None):
+        return FakeSI(user or t.username, pwd)
+
+    monkeypatch.setattr(conn_mod.ConnectionManager, "_create_connection", staticmethod(fake_create))
+    return conn_mod.ConnectionManager(cfg)
+
+
+def test_no_routing_signal_uses_startup_target(cm, monkeypatch):
+    monkeypatch.setattr(uaa_hub_routing, "routing_item", lambda *a, **k: None)
+    si = cm.connect()
+    assert si.user == "startup-user"   # startup config username
+    assert si.pwd is None              # routed path not taken
+
+
+def test_routed_uses_per_role_creds(cm, monkeypatch):
+    monkeypatch.setattr(uaa_hub_routing, "routing_item", lambda *a, **k: "MCP - syseng_elevated - vcenter-prod")
+    monkeypatch.setattr(uaa_hub_routing, "resolve_fields",
+                        lambda title, **k: {"username": "svc-elev", "password": "elev-pw"})
+    si = cm.connect()
+    assert si.user == "svc-elev"       # routed creds
+    assert si.pwd == "elev-pw"
+
+
+def test_routed_caches_per_account(cm, monkeypatch):
+    monkeypatch.setattr(uaa_hub_routing, "routing_item", lambda *a, **k: "MCP - syseng_elevated - vcenter-prod")
+    calls = {"n": 0}
+
+    def resolve(title, **k):
+        calls["n"] += 1
+        return {"username": "u", "password": "p"}
+
+    monkeypatch.setattr(uaa_hub_routing, "resolve_fields", resolve)
+    a = cm.connect()
+    b = cm.connect()
+    assert a is b              # cached per (target, account)
+    assert calls["n"] == 1     # resolved once; second call hit the live cache
+
+
+def test_distinct_accounts_get_distinct_connections(cm, monkeypatch):
+    titles = iter(["MCP - syseng_elevated - vcenter-prod", "MCP - syseng_readonly - vcenter-prod"])
+    monkeypatch.setattr(uaa_hub_routing, "routing_item", lambda *a, **k: next(titles))
+    monkeypatch.setattr(uaa_hub_routing, "resolve_fields",
+                        lambda title, **k: {"username": title, "password": "p"})
+    a = cm.connect()
+    b = cm.connect()
+    assert a is not b
+    assert {a.user, b.user} == {
+        "MCP - syseng_elevated - vcenter-prod", "MCP - syseng_readonly - vcenter-prod"
+    }
+
+
+def test_routed_missing_field_fails_closed(cm, monkeypatch):
+    monkeypatch.setattr(uaa_hub_routing, "routing_item", lambda *a, **k: "MCP - syseng_elevated - vcenter-prod")
+    monkeypatch.setattr(uaa_hub_routing, "resolve_fields",
+                        lambda title, **k: {"username": "u"})   # password missing
+    with pytest.raises(uaa_hub_routing.RoutingError):
+        cm.connect()
+
+
+def test_routing_error_propagates_denies(cm, monkeypatch):
+    def boom(*a, **k):
+        raise uaa_hub_routing.RoutingError("malformed X-Hub-Roles")
+    monkeypatch.setattr(uaa_hub_routing, "routing_item", boom)
+    with pytest.raises(uaa_hub_routing.RoutingError):
+        cm.connect()

--- a/tests/test_session_liveness.py
+++ b/tests/test_session_liveness.py
@@ -1,0 +1,74 @@
+"""Dead-session eviction tests for ConnectionManager.connect().
+
+The 2026-07-15 vmware-monitor v9 defect: the liveness probe's except clause
+named vmodl.fault.NotAuthenticated, which does not exist (the real fault is
+vim.fault.NotAuthenticated) - and Python evaluates except-tuples at catch
+time, so the handler itself raised AttributeError, skipped the cache
+eviction, and permafailed the target until a service restart. These tests
+pin the fixed behavior for BOTH dead-session shapes: probe raises, and
+currentSession None without raising. No pyVmomi, 1P, or vCenter required;
+runs with routing absent (_HUB_ROUTING False), which is also the CI shape.
+"""
+import pytest
+
+from vmware_aiops import connection as conn_mod
+from vmware_aiops.config import AppConfig, TargetConfig
+
+
+class _RaisingSess:
+    """Expired-session shape 1: property access raises (as NotAuthenticated does)."""
+    @property
+    def currentSession(self):
+        raise RuntimeError("NotAuthenticated")
+
+
+class _NoneSess:
+    """Expired-session shape 2: returns None without raising."""
+    currentSession = None
+
+
+class _LiveSess:
+    currentSession = object()
+
+
+class FakeSI:
+    def __init__(self, sess):
+        class _Content:
+            sessionManager = sess
+        self.content = _Content()
+
+
+@pytest.fixture
+def cm(monkeypatch):
+    monkeypatch.setattr(conn_mod, "_HUB_ROUTING", False)
+    target = TargetConfig(name="prod", host="vc.example", username="u", verify_ssl=False)
+    cfg = AppConfig(targets=(target,))
+
+    def fake_create(t, *, user=None, pwd=None):
+        return FakeSI(_LiveSess())
+
+    monkeypatch.setattr(conn_mod.ConnectionManager, "_create_connection", staticmethod(fake_create))
+    return conn_mod.ConnectionManager(cfg)
+
+
+def test_live_session_returned_from_cache(cm):
+    a = cm.connect()
+    b = cm.connect()
+    assert a is b
+
+
+def test_raising_probe_evicts_and_reconnects(cm):
+    corpse = FakeSI(_RaisingSess())
+    cm._connections["prod"] = corpse
+    si = cm.connect()
+    assert si is not corpse                      # never hand back the corpse
+    assert cm._connections["prod"] is si         # fresh session re-cached
+    assert cm.connect() is si                    # and healthy afterwards
+
+
+def test_none_current_session_evicts_and_reconnects(cm):
+    corpse = FakeSI(_NoneSess())
+    cm._connections["prod"] = corpse
+    si = cm.connect()
+    assert si is not corpse
+    assert cm._connections["prod"] is si

--- a/vmware_aiops/connection.py
+++ b/vmware_aiops/connection.py
@@ -9,7 +9,7 @@ import atexit
 import ssl
 from typing import TYPE_CHECKING
 
-from pyVmomi import vim, vmodl
+from pyVmomi import vim
 from pyVmomi.VmomiSupport import VmomiJSONEncoder  # noqa: F401
 
 if TYPE_CHECKING:
@@ -89,12 +89,22 @@ class ConnectionManager:
 
         if cache_key in self._connections:
             si = self._connections[cache_key]
+            # Liveness probe. Dead sessions either RAISE on access (the real
+            # fault is vim.fault.NotAuthenticated) or return currentSession
+            # None without raising. Catch bare Exception - NotAuthenticated
+            # does NOT exist under vmodl.fault, and Python evaluates
+            # except-tuples at catch time, so naming it there raised
+            # AttributeError DURING handling, skipped the eviction, and
+            # permafailed the target until restart (vmware-monitor v9
+            # defect, 2026-07-15).
+            alive = False
             try:
-                # Test if session is still alive
-                _ = si.content.sessionManager.currentSession
+                alive = si.content.sessionManager.currentSession is not None
+            except Exception:
+                alive = False
+            if alive:
                 return si
-            except (vmodl.fault.NotAuthenticated, Exception):
-                del self._connections[cache_key]
+            del self._connections[cache_key]
 
         if routed is None:
             si = self._create_connection(target)

--- a/vmware_aiops/connection.py
+++ b/vmware_aiops/connection.py
@@ -17,6 +17,22 @@ if TYPE_CHECKING:
 
 from vmware_aiops.config import AppConfig, TargetConfig, load_config
 
+# Component 6: per-request backend-credential routing (shared resolver lib).
+# Optional - absent in local/stdio dev; routing then no-ops and the startup
+# config credentials are used. vmware-monitor + vmware-aiops both front the
+# PROD vCenter, so both resolve `MCP - <role> - vcenter-prod`. syseng-only per
+# the C5 validator ACCESS matrix; the backend account's own RBAC enforces
+# read-vs-write (aiops is write-capable, so only syseng_elevated reaches it).
+try:
+    import uaa_hub_routing
+
+    _HUB_ROUTING = True
+    _VCENTER_SELECTOR = uaa_hub_routing.priority_selector(
+        ("syseng_elevated", "syseng_readonly")
+    )
+except ImportError:
+    _HUB_ROUTING = False
+
 
 # ServiceInstance is a pyVmomi ManagedObject — its __setattr__ rejects any
 # attribute not in its allowed list (raises "Managed object attributes are
@@ -47,24 +63,50 @@ class ConnectionManager:
         return cls(cfg)
 
     def connect(self, target_name: str | None = None) -> ServiceInstance:
-        """Connect to a target by name, or the default target."""
+        """Connect to a target by name, or the default target.
+
+        Component 6: when the hub validator routes the request (X-Hub-Roles
+        present), resolve the per-role vCenter username/password from 1Password
+        (`MCP - <role> - vcenter-prod`) and open the session with THOSE creds -
+        host/port/tls unchanged - cached per (target, routed account). No
+        routing signal (legacy bearer / non-hub / stdio) -> the startup-config
+        session, unchanged. Fail closed: a present-but-unresolvable signal
+        raises and the request is denied; it never falls back to the startup
+        credential on a routing miss.
+        """
         target = (
             self._config.get_target(target_name)
             if target_name
             else self._config.default_target
         )
 
-        if target.name in self._connections:
-            si = self._connections[target.name]
+        routed = (
+            uaa_hub_routing.routing_item("vcenter-prod", _VCENTER_SELECTOR)
+            if _HUB_ROUTING
+            else None
+        )
+        cache_key = target.name if routed is None else f"{target.name}#{routed}"
+
+        if cache_key in self._connections:
+            si = self._connections[cache_key]
             try:
                 # Test if session is still alive
                 _ = si.content.sessionManager.currentSession
                 return si
             except (vmodl.fault.NotAuthenticated, Exception):
-                del self._connections[target.name]
+                del self._connections[cache_key]
 
-        si = self._create_connection(target)
-        self._connections[target.name] = si
+        if routed is None:
+            si = self._create_connection(target)
+        else:
+            fields = uaa_hub_routing.resolve_fields(routed)
+            user, pw = fields.get("username"), fields.get("password")
+            if not user or not pw:
+                raise uaa_hub_routing.RoutingError(
+                    f"1P item {routed!r} missing username/password"
+                )
+            si = self._create_connection(target, user=user, pwd=pw)
+        self._connections[cache_key] = si
         return si
 
     def disconnect(self, target_name: str) -> None:
@@ -89,8 +131,15 @@ class ConnectionManager:
         return list(self._connections.keys())
 
     @staticmethod
-    def _create_connection(target: TargetConfig) -> ServiceInstance:
-        """Create a new pyVmomi connection."""
+    def _create_connection(
+        target: TargetConfig, *, user: str | None = None, pwd: str | None = None
+    ) -> ServiceInstance:
+        """Create a new pyVmomi connection.
+
+        ``user``/``pwd`` override the target's startup credentials (Component 6
+        per-role routing); when omitted, the target's own username + env
+        password are used (legacy/startup path).
+        """
         from pyVim.connect import Disconnect, SmartConnect
 
         context = None
@@ -101,8 +150,8 @@ class ConnectionManager:
 
         si = SmartConnect(
             host=target.host,
-            user=target.username,
-            pwd=target.password,
+            user=user or target.username,
+            pwd=pwd if pwd is not None else target.password,
             port=target.port,
             sslContext=context,
             disableSslCertValidation=not target.verify_ssl,


### PR DESCRIPTION
Companion to mcp-hub-deploy#34 - same bug class in the aiops ConnectionManager (connection.py:96). Routed per-role sessions idle out and permafail identically; aiops just gets restarted more often so it presents less.

See mcp-hub-deploy#34 for the full root-cause writeup (vmodl.fault.NotAuthenticated does not exist; except-tuples evaluate at catch time; the handler raised AttributeError and skipped eviction).

Fix mirrors the monitor patch: bare-Exception probe, currentSession-None counts as dead, dead evicts + reconnects. Three new tests pin both dead-session shapes plus the cache-preserved-when-live case, and run in the no-routing CI shape.

Local suite: 199 passed / 1 skipped with the change; the 9 failures (test_no_destructive_ops x8, test_release_blockers cp1252) fail identically on clean HEAD - pre-existing fork drift, not this PR. This repo has no CI (held fork), so the manual run is the gate. Shipped under Allen's in-session go, 2026-07-15.