### PR TITLE
feat: allow VMWARE_<NAME>_USERNAME env override for target username

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,3 +115,20 @@ def test_immutability() -> None:
     t = TargetConfig(name="x", host="h", username="u")
     with pytest.raises(AttributeError):
         t.name = "y"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_username_env_override(sample_config_file: Path, monkeypatch) -> None:
+    """Env VMWARE_<NAME>_USERNAME (same normalization as the password key)
+    overrides config.yaml so wrapper-resolved credential PAIRS stay atomic."""
+    monkeypatch.setenv("VMWARE_TEST_VC_USERNAME", "svc-elevated@vsphere.local")
+    cfg = load_config(sample_config_file)
+    assert cfg.targets[0].username == "svc-elevated@vsphere.local"
+    assert cfg.targets[1].username == "root"  # untouched target keeps config.yaml value
+
+
+@pytest.mark.unit
+def test_username_falls_back_to_config(sample_config_file: Path, monkeypatch) -> None:
+    monkeypatch.delenv("VMWARE_TEST_VC_USERNAME", raising=False)
+    cfg = load_config(sample_config_file)
+    assert cfg.targets[0].username == "admin@vsphere.local"

--- a/vmware_aiops/config.py
+++ b/vmware_aiops/config.py
@@ -196,11 +196,19 @@ def load_config(config_path: Path | None = None) -> AppConfig:
     with open(path) as f:
         raw = yaml.safe_load(f) or {}
 
+    # Username resolves env-first (VMWARE_<NAME>_USERNAME, same normalization
+    # as the password key) so a wrapper that pulls a credential pair from a
+    # secret store can supply BOTH halves - a config.yaml username paired with
+    # an env password from a different account logs in as nobody. config.yaml
+    # remains the fallback for local/dev use.
     targets = tuple(
         TargetConfig(
             name=t["name"],
             host=t["host"],
-            username=t.get("username", "administrator@vsphere.local"),
+            username=os.environ.get(
+                f"VMWARE_{t['name'].upper().replace('-', '_')}_USERNAME",
+                t.get("username", "administrator@vsphere.local"),
+            ),
             type=t.get("type", "vcenter"),
             port=t.get("port", 443),
             verify_ssl=t.get("verify_ssl", True),


### PR DESCRIPTION
Per-target credentials can already be supplied via the environment for the password (`VMWARE_<NAME>_PASSWORD`), but the username is only read from `config.yaml`. This asymmetry means an operator who keeps credentials out of a committed config file can externalize the password but not the username, so secret-injection setups (systemd `EnvironmentFile`, container secrets, a vault sidecar) still have to write the username into `config.yaml`.

This lets `VMWARE_<NAME>_USERNAME` override the per-target username the same way the password already works, using the same name normalization. When the env var is absent, behavior is unchanged (username comes from `config.yaml`).

About 10 lines in `config.py` plus a regression test covering env-set, env-absent, and the normalization.

Developed downstream against a vSphere 8 / VCF 9 environment and offered back.