### PR TITLE
feat: dvSwitch portgroup + host VMkernel network authoring tools

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -53,6 +53,7 @@ from mcp_server.tools import (  # noqa: F401 — imported for registration side 
     datastore,
     deploy,
     guest,
+    network,
     plan,
     summary,
     ttl,

--- a/mcp_server/tools/network.py
+++ b/mcp_server/tools/network.py
@@ -1,0 +1,229 @@
+"""Network tools: dvSwitch portgroups + host VMkernel adapters and MTU diagnostics."""
+
+from typing import Optional
+
+from vmware_policy import vmware_tool
+
+from mcp_server._shared import _get_connection, mcp, tool_errors
+from vmware_aiops.ops import host_network_mgmt, network_mgmt
+
+
+# ---------------------------------------------------------------------------
+# dvSwitch portgroups
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+@vmware_tool(risk_level="low")
+@tool_errors("dict")
+def list_dvs_portgroups(
+    dvs_name: Optional[str] = None,
+    target: Optional[str] = None,
+) -> dict:
+    """List distributed virtual portgroups, optionally scoped to one dvSwitch.
+
+    Per portgroup: name, parent dvSwitch, binding type (earlyBinding /
+    ephemeral), VLAN setting (id, trunk ranges, or pvlan), configured port
+    count, and whether it is the switch's uplink portgroup. Use to verify
+    create_dvs_portgroup results or to survey network config before changes.
+
+    Args:
+        dvs_name: dvSwitch name to scope to; omit to list across all switches.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Dict with total and portgroups list. Errors return a dict with "error" + hint.
+    """
+    si = _get_connection(target)
+    return network_mgmt.list_dvs_portgroups(si, dvs_name=dvs_name)
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True})
+@vmware_tool(risk_level="medium")
+@tool_errors("dict")
+def create_dvs_portgroup(
+    name: str,
+    dvs_name: str,
+    vlan_id: int,
+    binding: str = "earlyBinding",
+    num_ports: int = 8,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Create a VLAN-tagged portgroup on a dvSwitch - preview/confirm gated.
+
+    confirm=False (default) validates everything (switch exists, name free,
+    binding and VLAN legal) and returns the exact spec that WOULD be created
+    without writing anything. confirm=True creates the portgroup and waits
+    for the task. Verify afterwards with list_dvs_portgroups. Audited.
+
+    binding="ephemeral" creates a portgroup with no pre-created port pool,
+    attachable from the ESXi host client even when vCenter is down - use for
+    a self-hosted VCSA's own management portgroup. num_ports is ignored for
+    ephemeral. lateBinding is deprecated by vSphere and not offered.
+
+    Args:
+        name: Name for the new portgroup; must be unique on the switch.
+        dvs_name: Name of the distributed virtual switch to create it on.
+        vlan_id: VLAN ID to tag (0-4094; 0 = none).
+        binding: "earlyBinding" (default) or "ephemeral".
+        num_ports: Port count for earlyBinding portgroups (default 8).
+        confirm: False previews; True creates.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview", would_create) or result dict
+        (action="created", created). Errors return a dict with "error" + hint.
+    """
+    si = _get_connection(target)
+    return network_mgmt.create_dvs_portgroup(
+        si, name=name, dvs_name=dvs_name, vlan_id=vlan_id,
+        binding=binding, num_ports=num_ports, confirm=confirm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Host VMkernel adapters + MTU diagnostics
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+@vmware_tool(risk_level="low")
+@tool_errors("dict")
+def list_host_vmks(
+    host_name: Optional[str] = None,
+    target: Optional[str] = None,
+) -> dict:
+    """List VMkernel adapters, optionally scoped to one ESXi host.
+
+    Per vmk: device, IP/netmask/dhcp, MTU, MAC, portgroup (standard or DVS),
+    netstack, and which host services it is selected for (management,
+    vmotion, vsan, ...). The verify pair for add_host_vmk/remove_host_vmk.
+
+    Args:
+        host_name: ESXi host name; omit to list across all hosts.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Dict with total and vmks list. Errors return a dict with "error" + hint.
+    """
+    si = _get_connection(target)
+    return host_network_mgmt.list_host_vmks(si, host_name=host_name)
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True})
+@vmware_tool(risk_level="medium")
+@tool_errors("dict")
+def add_host_vmk(
+    host_name: str,
+    portgroup: str,
+    ip: str,
+    netmask: str,
+    mtu: int = 1500,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Add a static-IP VMkernel adapter on a DVS portgroup - preview/confirm gated.
+
+    Deliberately minimal shape for throwaway test vmks on L2-only segments
+    (e.g. a TEP VLAN): static IPv4, NO gateway, NO services enabled. The DVS
+    port allocation is handled internally - pass the distributed portgroup
+    name. confirm=False validates (host + portgroup exist, IP/netmask/MTU
+    legal, IP not already on the host) and returns the exact spec without
+    writing; confirm=True creates and returns the assigned device name.
+    Verify with list_host_vmks; remove with remove_host_vmk. Audited.
+
+    Args:
+        host_name: ESXi host to add the vmk on.
+        portgroup: Distributed portgroup name to connect to.
+        ip: Static IPv4 address for the vmk.
+        netmask: Subnet mask (e.g. 255.255.255.0).
+        mtu: MTU for the vmk (default 1500; 9000 for jumbo tests).
+        confirm: False previews; True creates.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview") or result dict (action="created",
+        device=e.g. "vmk2"). Errors return a dict with "error" + hint.
+    """
+    si = _get_connection(target)
+    return host_network_mgmt.add_host_vmk(
+        si, host_name=host_name, portgroup=portgroup, ip=ip,
+        netmask=netmask, mtu=mtu, confirm=confirm,
+    )
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True})
+@vmware_tool(risk_level="high")
+@tool_errors("dict")
+def remove_host_vmk(
+    host_name: str,
+    vmk: str,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Remove a VMkernel adapter - confirm-gated and service-guarded.
+
+    REFUSES to remove a vmk that is selected for any host service
+    (management/vmotion/vsan/...) - removing a management vmk severs the
+    host. Test vmks created by add_host_vmk have no services and remove
+    cleanly. confirm=False previews what would be removed.
+
+    Args:
+        host_name: ESXi host the vmk lives on.
+        vmk: Device name to remove (e.g. "vmk2").
+        confirm: False previews; True removes.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview") or result dict (action="removed").
+        Errors return a dict with "error" + hint.
+    """
+    si = _get_connection(target)
+    return host_network_mgmt.remove_host_vmk(
+        si, host_name=host_name, vmk=vmk, confirm=confirm,
+    )
+
+
+@mcp.tool(annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+@vmware_tool(risk_level="low")
+@tool_errors("dict")
+def vmk_ping(
+    host_name: str,
+    source_vmk: str,
+    dest_ip: str,
+    size: int = 56,
+    df: bool = False,
+    count: int = 3,
+    netstack: Optional[str] = None,
+    target: Optional[str] = None,
+) -> dict:
+    """DF-bit-capable ping sourced from a host vmk - MTU path validation.
+
+    Runs `esxcli network diag ping` on the ESXi host through the vSphere API
+    (no host SSH). df=True sets Don't-Fragment so an oversized packet FAILS
+    instead of fragmenting - that failure is the diagnostic:
+    - df=True size=1572 proves a >=1600 MTU path (overlay/TEP floor)
+    - df=True size=8972 proves full jumbo (9000 minus 28 bytes overhead)
+    A too-big result reports 'Message too long' in the fault field rather
+    than erroring - read success + fault together.
+
+    Args:
+        host_name: ESXi host to source the ping from.
+        source_vmk: VMkernel device to source from (e.g. "vmk2").
+        dest_ip: IPv4 address to ping.
+        size: ICMP payload bytes (default 56). Path proves size+28 MTU.
+        df: True sets the Don't-Fragment bit (the MTU probe mode).
+        count: Packets to send (default 3, max 60).
+        netstack: Optional netstack instance (e.g. "vxlan" for real TEP vmks).
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Dict with request, success, and summary (transmitted/received/loss/
+        rtt) or fault (the esxcli failure text). Errors return "error" + hint.
+    """
+    si = _get_connection(target)
+    return host_network_mgmt.vmk_ping(
+        si, host_name=host_name, source_vmk=source_vmk, dest_ip=dest_ip,
+        size=size, df=df, count=count, netstack=netstack,
+    )

--- a/tests/test_host_network_mgmt.py
+++ b/tests/test_host_network_mgmt.py
@@ -1,0 +1,275 @@
+"""Host vmk ops: validation, preview/confirm gates, service guard, esxcli
+ping arg construction + XML parsing shapes (incl. ESXi's 'Recieved' typo)."""
+import types
+
+import pytest
+
+from vmware_aiops.ops import host_network_mgmt as hnm
+from vmware_aiops.ops.host_network_mgmt import (
+    HostNetworkError,
+    HostNotFoundError,
+    add_host_vmk,
+    list_host_vmks,
+    remove_host_vmk,
+    vmk_ping,
+)
+
+
+def _vnic(device, ip=None, netmask="255.255.255.0", mtu=1500, mac="00:00:00:00:00:01"):
+    spec = types.SimpleNamespace(
+        ip=types.SimpleNamespace(ipAddress=ip, subnetMask=netmask, dhcp=False) if ip else None,
+        mtu=mtu, mac=mac, distributedVirtualPort=None, netStackInstanceKey="defaultTcpipStack",
+    )
+    return types.SimpleNamespace(device=device, spec=spec, portgroup="")
+
+
+class FakeNetworkSystem:
+    def __init__(self):
+        self.added = []
+        self.removed = []
+
+    def AddVirtualNic(self, portgroup, nic):
+        self.added.append((portgroup, nic))
+        return "vmk2"
+
+    def RemoveVirtualNic(self, device):
+        self.removed.append(device)
+
+
+def _nic_mgr(selected=()):
+    """virtualNicManager with vmk0 selected for management when requested."""
+    cand = types.SimpleNamespace(key="k-vmk0", device="vmk0")
+    cfgs = [
+        types.SimpleNamespace(nicType=t, selectedVnic=["k-vmk0"], candidateVnic=[cand])
+        for t in selected
+    ]
+    return types.SimpleNamespace(info=types.SimpleNamespace(netConfig=cfgs))
+
+
+def _host(vnics, selected_services=("management",)):
+    ns = FakeNetworkSystem()
+    host = types.SimpleNamespace(
+        name="esxi01.lab.example.com",
+        _moId="host-123",
+        config=types.SimpleNamespace(network=types.SimpleNamespace(vnic=vnics)),
+        configManager=types.SimpleNamespace(
+            networkSystem=ns, virtualNicManager=_nic_mgr(selected_services)
+        ),
+    )
+    return host, ns
+
+
+def _pg(name="pg-tep-test"):
+    return types.SimpleNamespace(
+        name=name,
+        key="dvportgroup-42",
+        config=types.SimpleNamespace(
+            distributedVirtualSwitch=types.SimpleNamespace(uuid="50 11 22 33")
+        ),
+    )
+
+
+@pytest.fixture
+def env(monkeypatch):
+    host, ns = _host([_vnic("vmk0", ip="192.0.2.11"), _vnic("vmk1", ip="192.0.2.21")])
+    monkeypatch.setattr(hnm, "find_host_by_name", lambda si, n: host if n == host.name else None)
+    monkeypatch.setattr(hnm, "_get_objects", lambda si, t: [_pg()])
+    return types.SimpleNamespace(host=host, ns=ns, si=object())
+
+
+# --- add_host_vmk ---------------------------------------------------------------
+
+def test_add_validates_before_any_write(env):
+    cases = [
+        dict(ip="not-an-ip", netmask="255.255.255.0", mtu=9000),
+        dict(ip="198.51.100.1", netmask="255.0.255.0", mtu=9000),   # non-contiguous mask
+        dict(ip="198.51.100.1", netmask="255.255.255.0", mtu=10),   # mtu too small
+        dict(ip="198.51.100.1", netmask="255.255.255.0", mtu=10000),
+        dict(ip="192.0.2.11", netmask="255.255.255.0", mtu=9000),   # duplicate host IP
+    ]
+    for kw in cases:
+        with pytest.raises(HostNetworkError):
+            add_host_vmk(env.si, env.host.name, "pg-tep-test", confirm=True, **kw)
+    assert env.ns.added == []
+
+
+def test_add_unknown_host_and_portgroup(env):
+    with pytest.raises(HostNotFoundError):
+        add_host_vmk(env.si, "nope-host", "pg-tep-test", "198.51.100.1", "255.255.255.0")
+    with pytest.raises(HostNetworkError, match="portgroup"):
+        add_host_vmk(env.si, env.host.name, "nope-pg", "198.51.100.1", "255.255.255.0")
+    assert env.ns.added == []
+
+
+def test_add_preview_never_writes(env):
+    out = add_host_vmk(env.si, env.host.name, "pg-tep-test",
+                       "198.51.100.1", "255.255.255.0", mtu=9000)
+    assert out["action"] == "preview"
+    assert out["would_create"]["mtu"] == 9000
+    assert out["would_create"]["gateway"] is None
+    assert out["would_create"]["services"] == []
+    assert env.ns.added == []
+
+
+def test_add_confirm_sends_exact_dvs_spec(env):
+    out = add_host_vmk(env.si, env.host.name, "pg-tep-test",
+                       "198.51.100.1", "255.255.255.0", mtu=9000, confirm=True)
+    assert out["action"] == "created"
+    assert out["device"] == "vmk2"
+    (portgroup_arg, nic), = env.ns.added
+    assert portgroup_arg == ""                       # DVS contract: empty std portgroup
+    assert nic.ip.ipAddress == "198.51.100.1"
+    assert nic.ip.subnetMask == "255.255.255.0"
+    assert nic.ip.dhcp is False
+    assert nic.mtu == 9000
+    assert nic.distributedVirtualPort.portgroupKey == "dvportgroup-42"
+    assert nic.distributedVirtualPort.switchUuid == "50 11 22 33"
+
+
+# --- remove_host_vmk ------------------------------------------------------------
+
+def test_remove_refuses_service_selected_vmk(env):
+    with pytest.raises(HostNetworkError, match="REFUSED"):
+        remove_host_vmk(env.si, env.host.name, "vmk0", confirm=True)
+    assert env.ns.removed == []
+
+
+def test_remove_unknown_vmk_lists_present(env):
+    with pytest.raises(HostNetworkError, match="vmk9"):
+        remove_host_vmk(env.si, env.host.name, "vmk9", confirm=True)
+
+
+def test_remove_preview_then_confirm(env):
+    out = remove_host_vmk(env.si, env.host.name, "vmk1")
+    assert out["action"] == "preview"
+    assert env.ns.removed == []
+    out = remove_host_vmk(env.si, env.host.name, "vmk1", confirm=True)
+    assert out["action"] == "removed"
+    assert env.ns.removed == ["vmk1"]
+
+
+# --- list ------------------------------------------------------------------------
+
+def test_list_reports_services_and_shape(env, monkeypatch):
+    monkeypatch.setattr(hnm, "_get_objects", lambda si, t: [env.host])
+    out = list_host_vmks(env.si)
+    by_dev = {v["device"]: v for v in out["vmks"]}
+    assert by_dev["vmk0"]["services"] == ["management"]
+    assert by_dev["vmk1"]["services"] == []
+    assert by_dev["vmk1"]["ip"] == "192.0.2.21"
+
+
+# --- vmk_ping --------------------------------------------------------------------
+
+MME_RETURN_XML = '<returnval type="ReflectManagedMethodExecuter">ha-mme-123</returnval>'
+
+# esxcli returns the PingOutput XML-escaped inside <response>, with ESXi's
+# genuine "Recieved"/"PacketLost" spellings.
+PING_OK_XML = (
+    "<ExecuteSoapResponse><returnval><response>"
+    "&lt;output xsi:type=&quot;vim.EsxCLI.network.diag.ping.PingOutput&quot;&gt;"
+    "&lt;Summary&gt;&lt;Duplicated&gt;0&lt;/Duplicated&gt;"
+    "&lt;HostAddr&gt;198.51.100.2&lt;/HostAddr&gt;"
+    "&lt;PacketLost&gt;0&lt;/PacketLost&gt;&lt;Recieved&gt;3&lt;/Recieved&gt;"
+    "&lt;RoundtripAvgMS&gt;512&lt;/RoundtripAvgMS&gt;"
+    "&lt;Transmitted&gt;3&lt;/Transmitted&gt;&lt;/Summary&gt;&lt;/output&gt;"
+    "</response></returnval></ExecuteSoapResponse>"
+)
+
+PING_FAULT_XML = (
+    "<ExecuteSoapResponse><returnval><fault>"
+    "<faultMsg>sendto() failed (Message too long)</faultMsg>"
+    "<faultMsg>sendto() failed (Message too long)</faultMsg>"
+    "</fault></returnval></ExecuteSoapResponse>"
+)
+
+
+def _wire_soap(monkeypatch, execute_response):
+    """First _soap_post call = RetrieveManagedMethodExecuter; second = ExecuteSoap."""
+    bodies = []
+
+    def fake_post(si, body):
+        bodies.append(body)
+        return MME_RETURN_XML if "RetrieveManagedMethodExecuter" in body else execute_response
+
+    monkeypatch.setattr(hnm, "_soap_post", fake_post)
+    return bodies
+
+
+def test_ping_success_parses_misspelled_received(env, monkeypatch):
+    bodies = _wire_soap(monkeypatch, PING_OK_XML)
+    out = vmk_ping(env.si, env.host.name, "vmk1", "198.51.100.2", size=8972, df=True)
+    assert out["success"] is True
+    assert out["summary"]["received"] == 3
+    assert out["summary"]["transmitted"] == 3
+    assert out["summary"]["packet_lost_pct"] == 0
+    execute = bodies[1]
+    assert "ha-mme-123" in execute
+    assert "<moid>ha-cli-handler-network-diag</moid>" in execute
+    assert "<method>vim.EsxCLI.network.diag.ping</method>" in execute
+    assert "<val>&lt;size&gt;8972&lt;/size&gt;</val>" in execute
+    assert "&lt;df&gt;true&lt;/df&gt;" in execute
+    assert "&lt;interface&gt;vmk1&lt;/interface&gt;" in execute
+    assert "netstack" not in execute
+
+
+def test_ping_df_too_big_returns_fault_not_error(env, monkeypatch):
+    _wire_soap(monkeypatch, PING_FAULT_XML)
+    out = vmk_ping(env.si, env.host.name, "vmk1", "198.51.100.2", size=8972, df=True)
+    assert out["success"] is False
+    assert "Message too long" in out["fault"]
+
+
+def test_ping_netstack_arg_included_when_set(env, monkeypatch):
+    bodies = _wire_soap(monkeypatch, PING_OK_XML)
+    vmk_ping(env.si, env.host.name, "vmk1", "198.51.100.2", netstack="vxlan")
+    assert "&lt;netstack&gt;vxlan&lt;/netstack&gt;" in bodies[1]
+
+
+# Live-verified vCenter shape (2026-07-16): reflect-namespaced <reflect:response>
+PING_NS_XML = (
+    "<ExecuteSoapResponse><returnval><reflect:response>"
+    "&lt;obj&gt;&lt;DataObject&gt;&lt;Summary&gt;"
+    "&lt;PacketLost&gt;0&lt;/PacketLost&gt;&lt;Recieved&gt;3&lt;/Recieved&gt;"
+    "&lt;RoundtripAvgMS&gt;0&lt;/RoundtripAvgMS&gt;"
+    "&lt;Transmitted&gt;3&lt;/Transmitted&gt;&lt;/Summary&gt;"
+    "&lt;/DataObject&gt;&lt;/obj&gt;"
+    "</reflect:response></returnval></ExecuteSoapResponse>"
+)
+
+
+def test_ping_parses_namespace_prefixed_response(env, monkeypatch):
+    _wire_soap(monkeypatch, PING_NS_XML)
+    out = vmk_ping(env.si, env.host.name, "vmk1", "198.51.100.2")
+    assert out["success"] is True
+    assert out["summary"]["received"] == 3
+    assert "raw_response" not in out
+
+
+def test_ping_ns_prefixed_fault_still_detected(env, monkeypatch):
+    _wire_soap(monkeypatch,
+               "<returnval><reflect:fault><reflect:faultMsg>sendto() failed "
+               "(Message too long)</reflect:faultMsg></reflect:fault></returnval>")
+    out = vmk_ping(env.si, env.host.name, "vmk1", "198.51.100.2", df=True, size=8972)
+    assert out["success"] is False
+    assert "Message too long" in out["fault"]
+
+
+def test_ping_soap_fault_raises(env, monkeypatch):
+    def fake_post(si, body):
+        raise HostNetworkError("SOAP fault: The session is not authenticated")
+
+    monkeypatch.setattr(hnm, "_soap_post", fake_post)
+    with pytest.raises(HostNetworkError, match="not authenticated"):
+        vmk_ping(env.si, env.host.name, "vmk1", "198.51.100.2")
+
+
+def test_ping_validation_fires_before_soap(env, monkeypatch):
+    bodies = _wire_soap(monkeypatch, PING_OK_XML)
+    for kw in (dict(dest_ip="bad"), dict(dest_ip="1.2.3.4", size=0),
+               dict(dest_ip="1.2.3.4", count=0)):
+        with pytest.raises(HostNetworkError):
+            vmk_ping(env.si, env.host.name, "vmk1", **kw)
+    with pytest.raises(HostNetworkError, match="vmk7"):
+        vmk_ping(env.si, env.host.name, "vmk7", "1.2.3.4")
+    assert bodies == []

--- a/tests/test_network_mgmt.py
+++ b/tests/test_network_mgmt.py
@@ -1,0 +1,145 @@
+"""dvSwitch portgroup ops: validation, preview/confirm gate, spec correctness.
+
+Probes input shapes, not just values: the preview leg must never write, the
+confirm leg must send exactly the validated spec, and every validation error
+must fire BEFORE any task is issued.
+"""
+import types
+
+import pytest
+from pyVmomi import vim
+
+from vmware_aiops.ops import network_mgmt
+from vmware_aiops.ops.network_mgmt import (
+    DvsNotFoundError,
+    NetworkError,
+    create_dvs_portgroup,
+    list_dvs_portgroups,
+)
+
+
+class FakePG:
+    def __init__(self, name, binding="earlyBinding", vlan=None, num_ports=8, uplink=False):
+        self.name = name
+        cfg = types.SimpleNamespace()
+        cfg.type = binding
+        cfg.numPorts = num_ports
+        cfg.uplink = uplink
+        cfg.defaultPortConfig = types.SimpleNamespace(vlan=vlan)
+        self.config = cfg
+
+
+class FakeDVS:
+    def __init__(self, name, portgroups=()):
+        self.name = name
+        self.portgroup = list(portgroups)
+        self.created_specs = []
+
+    def CreateDVPortgroup_Task(self, spec):
+        self.created_specs.append(spec)
+        return "fake-task"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """One switch with one existing portgroup; task-wait is a no-op recorder."""
+    vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+    vlan.vlanId = 100
+    dvs = FakeDVS("DSwitch", [FakePG("existing-pg", vlan=vlan)])
+    monkeypatch.setattr(network_mgmt, "_get_objects", lambda si, types_: [dvs])
+    waited = []
+    monkeypatch.setattr(network_mgmt, "_wait_for_task", lambda t: waited.append(t))
+    return types.SimpleNamespace(dvs=dvs, waited=waited, si=object())
+
+
+# --- validation (must all fire before any task) -------------------------------
+
+def test_rejects_bad_binding_including_deprecated_latebinding(env):
+    for bad in ("lateBinding", "static", "", "EPHEMERAL"):
+        with pytest.raises(NetworkError, match="binding"):
+            create_dvs_portgroup(env.si, "pg", "DSwitch", 100, binding=bad, confirm=True)
+    assert env.dvs.created_specs == []
+
+
+def test_rejects_vlan_out_of_range(env):
+    for bad in (-1, 4095, 99999):
+        with pytest.raises(NetworkError, match="vlan_id"):
+            create_dvs_portgroup(env.si, "pg", "DSwitch", bad, confirm=True)
+    assert env.dvs.created_specs == []
+
+
+def test_rejects_duplicate_name(env):
+    with pytest.raises(NetworkError, match="already exists"):
+        create_dvs_portgroup(env.si, "existing-pg", "DSwitch", 100, confirm=True)
+    assert env.dvs.created_specs == []
+
+
+def test_unknown_dvs_raises_with_available_list(env):
+    with pytest.raises(DvsNotFoundError, match="DSwitch"):
+        create_dvs_portgroup(env.si, "pg", "nope-vds", 100, confirm=True)
+    assert env.dvs.created_specs == []
+
+
+# --- preview/confirm gate ------------------------------------------------------
+
+def test_preview_validates_but_never_writes(env):
+    out = create_dvs_portgroup(env.si, "pg-app", "DSwitch", 100, binding="ephemeral")
+    assert out["action"] == "preview"
+    assert out["would_create"]["vlan_id"] == 100
+    assert out["would_create"]["binding"] == "ephemeral"
+    assert out["would_create"]["num_ports"] == 0  # ephemeral has no port pool
+    assert env.dvs.created_specs == []
+    assert env.waited == []
+
+
+def test_confirm_creates_with_exact_spec(env):
+    out = create_dvs_portgroup(
+        env.si, "pg-app", "DSwitch", 100, binding="earlyBinding",
+        num_ports=16, confirm=True,
+    )
+    assert out["action"] == "created"
+    assert len(env.dvs.created_specs) == 1
+    spec = env.dvs.created_specs[0]
+    assert spec.name == "pg-app"
+    assert spec.type == "earlyBinding"
+    assert spec.numPorts == 16
+    assert spec.defaultPortConfig.vlan.vlanId == 100
+    assert spec.defaultPortConfig.vlan.inherited is False
+    assert env.waited == ["fake-task"]
+
+
+def test_confirm_ephemeral_leaves_numports_unset(env):
+    create_dvs_portgroup(env.si, "pg-mgmt", "DSwitch", 100, binding="ephemeral", confirm=True)
+    spec = env.dvs.created_specs[0]
+    assert spec.type == "ephemeral"
+    assert not spec.numPorts  # vCenter ignores it; we never send a pool size
+
+
+# --- list ----------------------------------------------------------------------
+
+def test_list_reports_vlan_shapes(env, monkeypatch):
+    trunk = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
+    r = vim.NumericRange()
+    r.start, r.end = 100, 200
+    trunk.vlanId = [r]
+    pvlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
+    pvlan.pvlanId = 42
+    vlan_id = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+    vlan_id.vlanId = 100
+    dvs = FakeDVS("vds2", [
+        FakePG("a", vlan=vlan_id),
+        FakePG("b", vlan=trunk),
+        FakePG("c", vlan=pvlan),
+        FakePG("d", vlan=None),
+    ])
+    monkeypatch.setattr(network_mgmt, "_get_objects", lambda si, types_: [dvs])
+    out = list_dvs_portgroups(object())
+    vlans = {p["name"]: p["vlan"] for p in out["portgroups"]}
+    assert vlans == {"a": "100", "b": "trunk 100-200", "c": "pvlan 42", "d": "unset"}
+
+
+def test_list_scoped_to_named_dvs(env):
+    out = list_dvs_portgroups(env.si, dvs_name="DSwitch")
+    assert out["total"] == 1
+    assert out["portgroups"][0]["name"] == "existing-pg"
+    assert out["portgroups"][0]["vlan"] == "100"

--- a/vmware_aiops/ops/host_network_mgmt.py
+++ b/vmware_aiops/ops/host_network_mgmt.py
@@ -1,0 +1,440 @@
+"""Host VMkernel adapter management + MTU-path diagnostic.
+
+add/remove/list vmks ride the standard vSphere API (HostNetworkSystem).
+vmk_ping rides esxcli-over-API: HostSystem.RetrieveManagedMethodExecuter()
+-> ExecuteSoap on the host's "network diag ping" CLI handler - the same
+mechanism PowerCLI's Get-EsxCli uses, works through a vCenter connection,
+no host SSH required.
+
+Design notes:
+- add_host_vmk sets NO gateway (vSphere vmk IpConfig has no gateway field;
+  default routes are per-netstack) and enables NO services - both deliberate:
+  the use case is throwaway test vmks on L2-only segments (e.g. TEP VLANs).
+- remove_host_vmk refuses to remove a vmk that is selected for ANY host
+  service (management/vMotion/vSAN/...) - a test vmk has none; removing a
+  management vmk kills the host connection.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import TYPE_CHECKING
+
+from pyVmomi import vim
+
+from vmware_aiops.ops.inventory import find_host_by_name
+
+if TYPE_CHECKING:
+    from pyVmomi.vim import ServiceInstance
+
+
+def _get_objects(si: ServiceInstance, obj_type: list, recursive: bool = True) -> list:
+    """Container-view walk returning raw managed objects.
+
+    Local on purpose: the module enumerates small scoped sets (portgroups,
+    hosts) and reads nested config off each object, which the batched
+    PropertyCollector helpers in ``inventory`` don't cover; keeping the
+    helper here also keeps the module free of private cross-module imports.
+    """
+    content = si.RetrieveContent()
+    container = content.viewManager.CreateContainerView(
+        content.rootFolder, obj_type, recursive
+    )
+    try:
+        return list(container.view)
+    finally:
+        container.Destroy()
+
+
+class HostNetworkError(Exception):
+    """Raised on host-network operation failures."""
+
+
+class HostNotFoundError(HostNetworkError):
+    """Raised when an ESXi host is not found by name."""
+
+
+_MTU_MIN, _MTU_MAX = 68, 9190
+
+
+def _require_host(si: ServiceInstance, host_name: str) -> vim.HostSystem:
+    host = find_host_by_name(si, host_name)
+    if host is None:
+        raise HostNotFoundError(f"Host '{host_name}' not found")
+    return host
+
+
+def _find_dv_portgroup(si: ServiceInstance, name: str) -> vim.dvs.DistributedVirtualPortgroup:
+    for pg in _get_objects(si, [vim.dvs.DistributedVirtualPortgroup]):
+        if pg.name == name:
+            return pg
+    raise HostNetworkError(f"Distributed portgroup '{name}' not found")
+
+
+def _vmk_services(host: vim.HostSystem) -> dict[str, list[str]]:
+    """Map vmk device -> host services it is selected for (management, vmotion, ...)."""
+    services: dict[str, list[str]] = {}
+    vnic_mgr = host.configManager.virtualNicManager
+    if vnic_mgr is None or vnic_mgr.info is None:
+        return services
+    for net_cfg in vnic_mgr.info.netConfig or []:
+        for selected in net_cfg.selectedVnic or []:
+            for cand in net_cfg.candidateVnic or []:
+                if cand.key == selected:
+                    services.setdefault(cand.device, []).append(net_cfg.nicType)
+    return services
+
+
+def list_host_vmks(si: ServiceInstance, host_name: str | None = None) -> dict:
+    """List VMkernel adapters, optionally scoped to one host."""
+    hosts = (
+        [_require_host(si, host_name)]
+        if host_name
+        else _get_objects(si, [vim.HostSystem])
+    )
+    out = []
+    for host in hosts:
+        services = _vmk_services(host)
+        for vnic in host.config.network.vnic or []:
+            ip = vnic.spec.ip
+            dv_port = getattr(vnic.spec, "distributedVirtualPort", None)
+            out.append({
+                "host": host.name,
+                "device": vnic.device,
+                "ip": ip.ipAddress if ip else None,
+                "netmask": ip.subnetMask if ip else None,
+                "dhcp": bool(ip.dhcp) if ip else None,
+                "mtu": vnic.spec.mtu,
+                "mac": vnic.spec.mac,
+                "portgroup": vnic.portgroup or None,
+                "dvs_port": dv_port.portgroupKey if dv_port else None,
+                "netstack": getattr(vnic.spec, "netStackInstanceKey", None),
+                "services": services.get(vnic.device, []),
+            })
+    return {"total": len(out), "vmks": out}
+
+
+def add_host_vmk(
+    si: ServiceInstance,
+    host_name: str,
+    portgroup: str,
+    ip: str,
+    netmask: str,
+    mtu: int = 1500,
+    confirm: bool = False,
+) -> dict:
+    """Add a static-IP VMkernel adapter on a DVS portgroup, preview/confirm gated.
+
+    No gateway is set and no services are enabled - throwaway-test-vmk shape.
+    confirm=False validates and returns the exact spec; confirm=True creates
+    and returns the assigned device name (e.g. "vmk2").
+    """
+    try:
+        ipaddress.IPv4Address(ip)
+    except ValueError as e:
+        raise HostNetworkError(f"invalid IPv4 address {ip!r}: {e}") from e
+    try:
+        # Netmask must be a valid mask, not just any dotted quad.
+        ipaddress.IPv4Network(f"0.0.0.0/{netmask}")
+    except ValueError as e:
+        raise HostNetworkError(f"invalid netmask {netmask!r}: {e}") from e
+    if not (_MTU_MIN <= mtu <= _MTU_MAX):
+        raise HostNetworkError(f"mtu must be {_MTU_MIN}-{_MTU_MAX}, got {mtu}")
+
+    host = _require_host(si, host_name)
+    pg = _find_dv_portgroup(si, portgroup)
+
+    for vnic in host.config.network.vnic or []:
+        if vnic.spec.ip and vnic.spec.ip.ipAddress == ip:
+            raise HostNetworkError(
+                f"Host '{host_name}' already has {vnic.device} at {ip}"
+            )
+
+    planned = {
+        "host": host.name,
+        "portgroup": pg.name,
+        "ip": ip,
+        "netmask": netmask,
+        "mtu": mtu,
+        "gateway": None,
+        "services": [],
+    }
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_create": planned,
+            "hint": "Re-run with confirm=True to create.",
+        }
+
+    spec = vim.host.VirtualNic.Specification()
+    spec.ip = vim.host.IpConfig(dhcp=False, ipAddress=ip, subnetMask=netmask)
+    spec.mtu = mtu
+    spec.distributedVirtualPort = vim.dvs.PortConnection(
+        portgroupKey=pg.key,
+        switchUuid=pg.config.distributedVirtualSwitch.uuid,
+    )
+    # portgroup="" is the API contract for DVS-connected vmks.
+    device = host.configManager.networkSystem.AddVirtualNic(portgroup="", nic=spec)
+    return {"action": "created", "device": device, "created": planned}
+
+
+def remove_host_vmk(
+    si: ServiceInstance,
+    host_name: str,
+    vmk: str,
+    confirm: bool = False,
+) -> dict:
+    """Remove a VMkernel adapter, confirm-gated + service-guarded."""
+    host = _require_host(si, host_name)
+
+    existing = {v.device: v for v in host.config.network.vnic or []}
+    if vmk not in existing:
+        raise HostNetworkError(
+            f"'{vmk}' not found on '{host_name}'. Present: {sorted(existing) or 'none'}"
+        )
+    in_use = _vmk_services(host).get(vmk, [])
+    if in_use:
+        raise HostNetworkError(
+            f"REFUSED: {vmk} on '{host_name}' is selected for host services "
+            f"{in_use} - removing it could sever the host. Deselect the "
+            "services first if this is intentional."
+        )
+
+    target_ip = existing[vmk].spec.ip
+    doomed = {
+        "host": host.name,
+        "device": vmk,
+        "ip": target_ip.ipAddress if target_ip else None,
+    }
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_remove": doomed,
+            "hint": "Re-run with confirm=True to remove.",
+        }
+
+    host.configManager.networkSystem.RemoveVirtualNic(vmk)
+    return {"action": "removed", "removed": doomed}
+
+
+# --- vmk_ping (esxcli over API, raw SOAP) ---------------------------------------
+#
+# The ManagedMethodExecuter types are internal VMODL that modern pyVmomi does
+# not ship (this is how PowerCLI's Get-EsxCli works under the hood). Rather
+# than fragile dynamic type registration, we speak the two SOAP calls
+# directly against the SAME authenticated vCenter session pyVmomi already
+# holds (session cookie reuse) - no extra auth, no host SSH:
+#   1. RetrieveManagedMethodExecuter on the HostSystem -> per-host MME moid
+#   2. ExecuteSoap on that MME -> esxcli network diag ping
+
+_ESXCLI_PING_MOID = "ha-cli-handler-network-diag"
+_ESXCLI_PING_METHOD = "vim.EsxCLI.network.diag.ping"
+_ESXCLI_VERSION = "urn:vim25/5.0"
+
+_SOAP_ENVELOPE = (
+    '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+    "<soapenv:Body>{body}</soapenv:Body></soapenv:Envelope>"
+)
+
+
+def _soap_post(si: ServiceInstance, body: str) -> str:
+    """POST one SOAP body to the connected vCenter's /sdk, reusing the live
+    pyVmomi session cookie. Returns the raw response XML; raises
+    HostNetworkError on transport errors or SOAP faults."""
+    import ssl
+
+    import httpx
+
+    stub = si._stub
+    hostport = stub.host if ":" in stub.host else f"{stub.host}:443"
+    ssl_ctx = getattr(stub, "sslContext", None)
+    if ssl_ctx is not None and ssl_ctx.verify_mode == 0:
+        verify = False  # ignore_ssl target - match the pyVmomi session's posture
+    else:
+        # Verify against the SYSTEM CA store (where hub-installed roots like
+        # the v9 VMCA live). httpx's default is the bundled certifi store,
+        # which does NOT see system-added roots - pyVmomi verifies via the
+        # system store, and this SOAP call must trust exactly what it trusts.
+        verify = ssl.create_default_context()
+    try:
+        r = httpx.post(
+            f"https://{hostport}/sdk",
+            content=_SOAP_ENVELOPE.format(body=body),
+            headers={
+                "Content-Type": "text/xml; charset=utf-8",
+                "SOAPAction": "urn:vim25/5.0",
+                "Cookie": stub.cookie or "",
+            },
+            verify=verify,
+            timeout=90.0,
+        )
+    except Exception as e:
+        raise HostNetworkError(f"SOAP transport failed: {e}") from e
+    fault = re.search(r"<faultstring>\s*(.*?)\s*</faultstring>", r.text, re.DOTALL)
+    if fault:
+        raise HostNetworkError(f"SOAP fault: {fault.group(1)[:300]}")
+    if r.status_code != 200:
+        raise HostNetworkError(f"SOAP HTTP {r.status_code}: {r.text[:200]}")
+    return r.text
+
+
+def _retrieve_mme_moid(si: ServiceInstance, host: vim.HostSystem) -> str:
+    body = (
+        '<RetrieveManagedMethodExecuter xmlns="urn:vim25">'
+        f'<_this type="HostSystem">{host._moId}</_this>'
+        "</RetrieveManagedMethodExecuter>"
+    )
+    xml = _soap_post(si, body)
+    m = re.search(r"<returnval[^>]*>\s*([^<\s]+)\s*</returnval>", xml)
+    if not m:
+        raise HostNetworkError(
+            f"could not locate ManagedMethodExecuter moid in response: {xml[:200]}"
+        )
+    return m.group(1)
+
+# PingOutput field tags of interest. ESXi's schema genuinely misspells
+# "Recieved" and uses "PacketLost"; accept correct spellings too.
+_PING_FIELDS = {
+    "transmitted": ("Transmitted",),
+    "received": ("Recieved", "Received"),
+    "packet_lost_pct": ("PacketLost",),
+    "roundtrip_avg_ms": ("RoundtripAvgMS", "RoundtripAvg"),
+    "host_addr": ("HostAddr",),
+}
+
+
+def _xml_tag(name: str, value) -> str:
+    return f"<{name}>{value}</{name}>"
+
+
+def _parse_ping_xml(xml: str) -> dict:
+    """Pull the summary fields out of the esxcli PingOutput XML, defensively."""
+    out: dict = {}
+    for field, tags in _PING_FIELDS.items():
+        for tag in tags:
+            m = re.search(rf"<{tag}>\s*([^<]*?)\s*</{tag}>", xml)
+            if m:
+                val = m.group(1)
+                try:
+                    out[field] = float(val) if "." in val else int(val)
+                except ValueError:
+                    out[field] = val
+                break
+    return out
+
+
+def vmk_ping(
+    si: ServiceInstance,
+    host_name: str,
+    source_vmk: str,
+    dest_ip: str,
+    size: int = 56,
+    df: bool = False,
+    count: int = 3,
+    netstack: str | None = None,
+) -> dict:
+    """DF-bit-capable ping sourced from a host vmk - the MTU path validator.
+
+    Runs `esxcli network diag ping` on the host through the vSphere API
+    (ManagedMethodExecuter), no SSH. df=True + size probes path MTU:
+    e.g. size=1572 proves a >=1600 overlay floor, size=8972 proves full
+    jumbo (9000 minus 28 bytes ICMP/IP overhead). A too-big DF'd packet
+    fails with "sendto() failed (Message too long)" - that failure IS the
+    diagnostic signal, reported per-packet, not raised.
+    """
+    try:
+        ipaddress.IPv4Address(dest_ip)
+    except ValueError as e:
+        raise HostNetworkError(f"invalid IPv4 address {dest_ip!r}: {e}") from e
+    if not (0 < size <= 65507):
+        raise HostNetworkError(f"size must be 1-65507, got {size}")
+    if not (1 <= count <= 60):
+        raise HostNetworkError(f"count must be 1-60, got {count}")
+
+    host = _require_host(si, host_name)
+    devices = {v.device for v in host.config.network.vnic or []}
+    if source_vmk not in devices:
+        raise HostNetworkError(
+            f"'{source_vmk}' not found on '{host_name}'. Present: {sorted(devices)}"
+        )
+
+    from xml.sax.saxutils import escape
+
+    args = [
+        ("count", count),
+        ("host", dest_ip),
+        ("interface", source_vmk),
+        ("size", size),
+    ]
+    if df:
+        args.append(("df", "true"))
+    if netstack:
+        args.append(("netstack", netstack))
+    # The CLI handler validates the argument array against the method's
+    # declared parameter order, which follows the esxcli metadata's
+    # alphabetical convention - an out-of-order array faults with
+    # "A specified parameter was not correct: argument[N]" (govmomi solves
+    # this by fetching the param metadata; sorted names match it for ping).
+    args.sort(key=lambda kv: kv[0])
+
+    mme_moid = _retrieve_mme_moid(si, host)
+    argument_xml = "".join(
+        f"<argument><name>{n}</name><val>{escape(_xml_tag(n, v))}</val></argument>"
+        for n, v in args
+    )
+    body = (
+        '<ExecuteSoap xmlns="urn:vim25">'
+        f'<_this type="ReflectManagedMethodExecuter">{mme_moid}</_this>'
+        f"<moid>{_ESXCLI_PING_MOID}</moid>"
+        f"<version>{_ESXCLI_VERSION}</version>"
+        f"<method>{_ESXCLI_PING_METHOD}</method>"
+        f"{argument_xml}"
+        "</ExecuteSoap>"
+    )
+    xml = _soap_post(si, body)
+
+    request = {
+        "host": host.name,
+        "source_vmk": source_vmk,
+        "dest_ip": dest_ip,
+        "size": size,
+        "df": df,
+        "count": count,
+        "netstack": netstack,
+    }
+    # esxcli-level failure comes back inside the result as <fault><faultMsg>
+    # (e.g. every DF'd packet oversized, bad netstack). For MTU probing this
+    # IS the answer - return it structured, not as an error. vCenter
+    # serializes the reflect types WITH a namespace prefix
+    # (<reflect:response>, live-verified 2026-07-16) - match both.
+    fault_msgs = re.findall(
+        r"<(?:\w+:)?faultMsg>\s*(.*?)\s*</(?:\w+:)?faultMsg>", xml, re.DOTALL
+    )
+    if fault_msgs:
+        return {
+            "request": request,
+            "success": False,
+            "fault": "; ".join(fault_msgs)[:500],
+            "hint": "For df=True, 'Message too long' means the path MTU is below size+28.",
+        }
+    # The PingOutput arrives XML-escaped inside <response> (possibly
+    # namespace-prefixed); unescape once.
+    resp = re.search(
+        r"<(?:\w+:)?response[^>]*>(.*)</(?:\w+:)?response>", xml, re.DOTALL
+    )
+    from xml.sax.saxutils import unescape
+
+    summary = _parse_ping_xml(unescape(resp.group(1)) if resp else xml)
+    received = summary.get("received", 0)
+    out = {
+        "request": request,
+        "success": isinstance(received, int) and received > 0,
+        "summary": summary,
+    }
+    if not summary:
+        # Unrecognized response shape - never swallow it silently; the raw
+        # excerpt is the only way to adapt the parser to a new ACOS/ESXi
+        # schema without SSHing anywhere.
+        out["raw_response"] = xml[-1200:]
+    return out

--- a/vmware_aiops/ops/network_mgmt.py
+++ b/vmware_aiops/ops/network_mgmt.py
@@ -1,0 +1,164 @@
+"""dvSwitch portgroup management: list + preview/confirm-gated create.
+
+First network-authoring surface in aiops. Create is gated per house
+convention: confirm=False returns a preview of exactly what would be
+created (and validates everything it can without writing); confirm=True
+executes. Ephemeral binding is first-class - an ephemeral portgroup is
+attachable from the ESXi host client even with vCenter down, which is
+the self-hosted-VCSA use case.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyVmomi import vim
+
+from vmware_aiops.ops.vm_lifecycle import _wait_for_task
+
+if TYPE_CHECKING:
+    from pyVmomi.vim import ServiceInstance
+
+
+def _get_objects(si: ServiceInstance, obj_type: list, recursive: bool = True) -> list:
+    """Container-view walk returning raw managed objects.
+
+    Local on purpose: the module enumerates small sets (dvSwitches) and then
+    reads nested config off each object, which the batched PropertyCollector
+    helpers in ``inventory`` don't cover; keeping the helper here also keeps
+    the module free of private cross-module imports.
+    """
+    content = si.RetrieveContent()
+    container = content.viewManager.CreateContainerView(
+        content.rootFolder, obj_type, recursive
+    )
+    try:
+        return list(container.view)
+    finally:
+        container.Destroy()
+
+
+class NetworkError(Exception):
+    """Raised on network operation failures."""
+
+
+class DvsNotFoundError(NetworkError):
+    """Raised when a distributed virtual switch is not found by name."""
+
+
+# lateBinding is deprecated by vSphere; do not offer it.
+_VALID_BINDINGS = {"earlyBinding", "ephemeral"}
+_VLAN_MIN, _VLAN_MAX = 0, 4094
+
+
+def _find_dvs_by_name(si: ServiceInstance, name: str) -> vim.DistributedVirtualSwitch:
+    for dvs in _get_objects(si, [vim.DistributedVirtualSwitch]):
+        if dvs.name == name:
+            return dvs
+    available = sorted(d.name for d in _get_objects(si, [vim.DistributedVirtualSwitch]))
+    raise DvsNotFoundError(
+        f"Distributed switch '{name}' not found. Available: {available or 'none'}"
+    )
+
+
+def _vlan_description(port_config) -> str:
+    """Human-readable VLAN setting of a portgroup's defaultPortConfig."""
+    vlan = getattr(port_config, "vlan", None)
+    if vlan is None:
+        return "unset"
+    if isinstance(vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+        ranges = ",".join(
+            f"{r.start}-{r.end}" if r.start != r.end else str(r.start)
+            for r in (vlan.vlanId or [])
+        )
+        return f"trunk {ranges or 'all'}"
+    if isinstance(vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+        return f"pvlan {vlan.pvlanId}"
+    if isinstance(vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
+        return str(vlan.vlanId)
+    return type(vlan).__name__
+
+
+def list_dvs_portgroups(si: ServiceInstance, dvs_name: str | None = None) -> dict:
+    """List distributed portgroups, optionally scoped to one dvSwitch."""
+    switches = (
+        [_find_dvs_by_name(si, dvs_name)]
+        if dvs_name
+        else _get_objects(si, [vim.DistributedVirtualSwitch])
+    )
+    out = []
+    for dvs in switches:
+        for pg in dvs.portgroup or []:
+            cfg = pg.config
+            out.append({
+                "name": pg.name,
+                "dvs": dvs.name,
+                "binding": str(cfg.type),
+                "vlan": _vlan_description(cfg.defaultPortConfig),
+                "num_ports": cfg.numPorts,
+                "uplink": bool(getattr(cfg, "uplink", False)),
+            })
+    return {"total": len(out), "portgroups": out}
+
+
+def create_dvs_portgroup(
+    si: ServiceInstance,
+    name: str,
+    dvs_name: str,
+    vlan_id: int,
+    binding: str = "earlyBinding",
+    num_ports: int = 8,
+    confirm: bool = False,
+) -> dict:
+    """Create a VLAN-tagged portgroup on a dvSwitch, preview/confirm gated.
+
+    confirm=False validates (switch exists, name free on that switch, binding
+    and VLAN legal) and returns the exact spec that WOULD be created, without
+    writing. confirm=True creates it and waits for the task.
+    """
+    if binding not in _VALID_BINDINGS:
+        raise NetworkError(
+            f"binding must be one of {sorted(_VALID_BINDINGS)}, got '{binding}' "
+            "(lateBinding is deprecated by vSphere and not offered)"
+        )
+    if not (_VLAN_MIN <= vlan_id <= _VLAN_MAX):
+        raise NetworkError(f"vlan_id must be {_VLAN_MIN}-{_VLAN_MAX}, got {vlan_id}")
+    if binding == "earlyBinding" and num_ports < 1:
+        raise NetworkError(f"num_ports must be >= 1 for earlyBinding, got {num_ports}")
+
+    dvs = _find_dvs_by_name(si, dvs_name)
+    existing = {pg.name for pg in dvs.portgroup or []}
+    if name in existing:
+        raise NetworkError(f"Portgroup '{name}' already exists on '{dvs_name}'")
+
+    # Ephemeral portgroups have no pre-created port pool; vCenter ignores
+    # numPorts for them - report 0 to keep the preview honest.
+    effective_ports = num_ports if binding == "earlyBinding" else 0
+    planned = {
+        "name": name,
+        "dvs": dvs.name,
+        "vlan_id": vlan_id,
+        "binding": binding,
+        "num_ports": effective_ports,
+    }
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_create": planned,
+            "hint": "Re-run with confirm=True to create.",
+        }
+
+    spec = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
+    spec.name = name
+    spec.type = binding
+    if binding == "earlyBinding":
+        spec.numPorts = num_ports
+    port_config = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
+    vlan_spec = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+    vlan_spec.vlanId = vlan_id
+    vlan_spec.inherited = False
+    port_config.vlan = vlan_spec
+    spec.defaultPortConfig = port_config
+
+    _wait_for_task(dvs.CreateDVPortgroup_Task(spec))
+    return {"action": "created", "created": planned}


### PR DESCRIPTION
Adds two network-authoring surfaces in a new `mcp_server/tools/network.py`, following the existing preview/confirm house pattern. Developed downstream against a vSphere 8 / VCF 9 environment (NSX transport-node bring-up) and offered back.

## dvSwitch portgroups
- `list_dvs_portgroups(dvs_name?)` - read: name, parent dvSwitch, binding type, VLAN setting (id / trunk ranges / pvlan), configured port count, uplink flag.
- `create_dvs_portgroup(name, dvs_name, vlan_id, binding, num_ports, confirm)` - write, gated: `confirm=False` validates (switch exists, name free, binding and VLAN legal) and returns the exact spec that would be created without writing; `confirm=True` creates and waits for the task.

Ephemeral binding is first-class: an ephemeral portgroup has no pre-created port pool and is attachable from the ESXi host client even with vCenter down, which is the self-hosted-VCSA management-network case. `lateBinding` is deprecated by vSphere and deliberately not offered.

## Host VMkernel adapters + MTU diagnostics
- `list_host_vmks(host_name?)` - read: device, IP/netmask/dhcp, MTU, MAC, portgroup, netstack, and which services each vmk is selected for.
- `add_host_vmk(...)` - write, preview/confirm-gated. Deliberately minimal shape: static IPv4, no gateway, no services enabled - the target use case is throwaway test vmks on L2-only segments (e.g. an NSX TEP VLAN during transport-node validation).
- `remove_host_vmk(...)` - write, confirm-gated and service-guarded: refuses to remove a vmk selected for any host service (management/vMotion/vSAN/...), so it cannot sever a host.
- `vmk_ping(host, source_vmk, dest_ip, size, df, count, netstack?)` - DF-bit-capable ping sourced from a host vmk, for MTU-path validation. `df=True size=1572` proves a >=1600 MTU overlay path; `df=True size=8972` proves full jumbo.

### Implementation note (may save the next person some time)
`vmk_ping` runs `esxcli network diag ping` through the vSphere API (no host SSH) via the reflect ManagedMethodExecuter. A few wire facts that were non-obvious:
- The `ReflectManagedMethodExecuter` VMODL type is internal and absent from modern pyVmomi, so the call is issued as raw SOAP reusing the pyVmomi session cookie against `https://<host>/sdk`.
- `httpx` verifies against certifi, not the system store, so the SOAP call must pass `ssl.create_default_context()` or host certs will not verify.
- `ExecuteSoap` arguments must be in the handler's declared (alphabetical) order or vCenter rejects them as `argument[N]`.
- vCenter serializes the reflect result namespaced (`<reflect:response>`), so a bare-tag parse matches nothing; the parser returns a raw-response excerpt on a parse miss.

## Tests
Full unit coverage for both surfaces (validation, preview-never-writes, exact-spec-on-confirm, service-guard, DF pass/fail parsing, namespaced-response parsing). Fixtures use RFC 5737 / example.com placeholders. Registered as one `tools/network.py` module; happy to split into `network.py` + `host_network.py` if you prefer the per-category layout.