### PR TITLE
feat: set_vmk_service - tag/untag host services on a VMkernel adapter

### DIFF
--- a/tests/test_host_network_mgmt.py
+++ b/tests/test_host_network_mgmt.py
@@ -475,3 +475,111 @@ def test_soap_post_verify_true_uses_system_ca_context(monkeypatch):
     verify = _capture_soap_verify(monkeypatch, verify_ssl_returns=True)
     # Verified against the system store (an SSLContext), never certifi/default True.
     assert isinstance(verify, ssl.SSLContext)
+
+
+# --- set_vmk_service ------------------------------------------------------------
+
+class FakeVnicManager:
+    """Stateful virtualNicManager: selections mutate via Select/Deselect."""
+
+    def __init__(self, selections):
+        self.calls = []
+        self._sel = {d: list(s) for d, s in selections.items()}
+
+    @property
+    def info(self):
+        devices = sorted(self._sel)
+        cands = [types.SimpleNamespace(key=f"k-{d}", device=d) for d in devices]
+        nic_types = sorted({t for s in self._sel.values() for t in s})
+        cfgs = [
+            types.SimpleNamespace(
+                nicType=t,
+                selectedVnic=[f"k-{d}" for d in devices if t in self._sel[d]],
+                candidateVnic=cands,
+            )
+            for t in nic_types
+        ]
+        return types.SimpleNamespace(netConfig=cfgs)
+
+    def SelectVnicForNicType(self, nicType, device):  # noqa: N802, N803 - pyVmomi API
+        self.calls.append(("select", nicType, device))
+        self._sel.setdefault(device, []).append(nicType)
+
+    def DeselectVnicForNicType(self, nicType, device):  # noqa: N802, N803 - pyVmomi API
+        self.calls.append(("deselect", nicType, device))
+        self._sel[device].remove(nicType)
+
+
+def _svc_env(monkeypatch, selections):
+    host, _ = _host([_vnic("vmk0", ip="192.0.2.11"), _vnic("vmk3", ip="192.0.2.31")])
+    mgr = FakeVnicManager(selections)
+    host.configManager.virtualNicManager = mgr
+    monkeypatch.setattr(hnm, "find_host_by_name",
+                        lambda si, n: host if n == host.name else None)
+    return host, mgr
+
+
+def test_set_service_validates_service_and_vmk(monkeypatch):
+    host, mgr = _svc_env(monkeypatch, {"vmk0": ["management"]})
+    with pytest.raises(hnm.HostNetworkError, match="Unknown service"):
+        hnm.set_vmk_service(object(), host.name, "vmk3", "provisioning", True, confirm=True)
+    with pytest.raises(hnm.HostNetworkError, match="not found"):
+        hnm.set_vmk_service(object(), host.name, "vmk9", "vmotion", True, confirm=True)
+    with pytest.raises(hnm.HostNotFoundError):
+        hnm.set_vmk_service(object(), "nope-host", "vmk3", "vmotion", True)
+    assert mgr.calls == []
+
+
+def test_set_service_refuses_unreadable_map_both_directions(monkeypatch):
+    host, mgr = _svc_env(monkeypatch, {"vmk0": ["management"]})
+    host.configManager.virtualNicManager = types.SimpleNamespace(
+        info=None, SelectVnicForNicType=mgr.SelectVnicForNicType,
+        DeselectVnicForNicType=mgr.DeselectVnicForNicType,
+    )
+    for enabled in (True, False):
+        with pytest.raises(hnm.HostNetworkError, match="cannot be read"):
+            hnm.set_vmk_service(object(), host.name, "vmk3", "vmotion", enabled, confirm=True)
+    assert mgr.calls == []
+
+
+def test_set_service_absolute_mgmt_guard(monkeypatch):
+    host, mgr = _svc_env(monkeypatch, {"vmk0": ["management"], "vmk3": ["vmotion"]})
+    with pytest.raises(hnm.HostNetworkError, match="ONLY management-enabled"):
+        hnm.set_vmk_service(object(), host.name, "vmk0", "management", False, confirm=True)
+    assert mgr.calls == []
+
+
+def test_set_service_mgmt_disable_ok_with_second_mgmt_vmk(monkeypatch):
+    host, mgr = _svc_env(monkeypatch,
+                         {"vmk0": ["management"], "vmk3": ["management"]})
+    out = hnm.set_vmk_service(object(), host.name, "vmk3", "management", False, confirm=True)
+    assert out["action"] == "set"
+    assert mgr.calls == [("deselect", "management", "vmk3")]
+
+
+def test_set_service_noop_never_writes(monkeypatch):
+    host, mgr = _svc_env(monkeypatch, {"vmk0": ["management"], "vmk3": ["vmotion"]})
+    out = hnm.set_vmk_service(object(), host.name, "vmk3", "vmotion", True, confirm=True)
+    assert out["action"] == "noop"
+    out = hnm.set_vmk_service(object(), host.name, "vmk3", "vsan", False, confirm=True)
+    assert out["action"] == "noop"
+    assert mgr.calls == []
+
+
+def test_set_service_preview_never_writes(monkeypatch):
+    host, mgr = _svc_env(monkeypatch, {"vmk0": ["management"], "vmk3": []})
+    out = hnm.set_vmk_service(object(), host.name, "vmk3", "vmotion", True)
+    assert out["action"] == "preview"
+    assert out["would_set"]["current_services"] == []
+    assert mgr.calls == []
+
+
+def test_set_service_confirm_enable_and_disable_roundtrip(monkeypatch):
+    host, mgr = _svc_env(monkeypatch, {"vmk0": ["management"], "vmk3": []})
+    out = hnm.set_vmk_service(object(), host.name, "vmk3", "vmotion", True, confirm=True)
+    assert out["action"] == "set"
+    assert out["services_now"] == ["vmotion"]
+    out = hnm.set_vmk_service(object(), host.name, "vmk3", "vmotion", False, confirm=True)
+    assert out["action"] == "set"
+    assert out["services_now"] == []
+    assert mgr.calls == [("select", "vmotion", "vmk3"), ("deselect", "vmotion", "vmk3")]

--- a/vmware_aiops/mcp_server/tools/network.py
+++ b/vmware_aiops/mcp_server/tools/network.py
@@ -212,6 +212,53 @@ def remove_host_vmk(
     )
 
 
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+@vmware_tool(risk_level="medium")
+@tool_errors("dict")
+def set_vmk_service(
+    host_name: str,
+    vmk: str,
+    service: str,
+    enabled: bool,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Enable/disable a host service on an existing vmk - preview/confirm gated.
+
+    Completes the add_host_vmk story: adapters are created serviceless by
+    design, then tagged here (e.g. enable "vmotion" on a new vMotion vmk).
+    Idempotent - re-applying the current state returns a no-write noop.
+    Verify with list_host_vmks (the services field). Audited.
+
+    Valid services are the vSphere nicType names: management, vmotion, vsan,
+    vSphereProvisioning, faultToleranceLogging, vSphereReplication,
+    vSphereReplicationNFC, vSphereBackupNFC, ptp, and the nvme/vsan variants.
+    Note "vSphereProvisioning", not "provisioning".
+
+    FAIL CLOSED: refuses both directions when the host's service map cannot
+    be read. ABSOLUTE, no override: disabling management on the host's only
+    management-enabled vmk - the call rides the interface it would untag.
+
+    Args:
+        host_name: ESXi host the vmk lives on.
+        vmk: Device name to change (e.g. "vmk3").
+        service: Service/nicType name to enable or disable.
+        enabled: True selects the vmk for the service; False deselects.
+        confirm: False previews; True applies.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview"), noop dict (action="noop") when the
+        state already matches, or result dict (action="set", services_now).
+        Errors return a dict with "error" + hint.
+    """
+    si = _get_connection(target)
+    return host_network_mgmt.set_vmk_service(
+        si, host_name=host_name, vmk=vmk, service=service,
+        enabled=enabled, confirm=confirm,
+    )
+
+
 @mcp.tool(annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
 @vmware_tool(risk_level="medium")
 @tool_errors("dict")

--- a/vmware_aiops/ops/host_network_mgmt.py
+++ b/vmware_aiops/ops/host_network_mgmt.py
@@ -353,6 +353,107 @@ def remove_host_vmk(
     return result
 
 
+# vim.host.VirtualNicManager.NicType enum values (pyVmomi 8/9). Kept as a
+# static allowlist so an unknown/mistyped service fails loudly at validation
+# instead of surfacing as an opaque vCenter fault at call time.
+_NIC_TYPES = frozenset({
+    "management", "vmotion", "vsan", "vSphereProvisioning",
+    "faultToleranceLogging", "vSphereReplication", "vSphereReplicationNFC",
+    "vSphereBackupNFC", "ptp", "nvmeRdma", "nvmeTcp", "vnetworking",
+    "vsanExternal", "vsanReplication", "vsanWitness",
+})
+
+
+def set_vmk_service(
+    si: ServiceInstance,
+    host_name: str,
+    vmk: str,
+    service: str,
+    enabled: bool,
+    confirm: bool = False,
+) -> dict:
+    """Enable/disable a host service (nicType) on an existing vmk - confirm-gated.
+
+    FAIL CLOSED: when the host's service map cannot be read, BOTH directions
+    refuse - idempotence checks and the management guard below each need the
+    verified current state, and unverifiable is never treated as safe.
+
+    ABSOLUTE (no override): disabling ``management`` on the host's only
+    management-enabled vmk. The call rides the interface it would untag;
+    after it succeeded, nothing could reach the host to undo it.
+    """
+    host = _require_host(si, host_name)
+
+    if service not in _NIC_TYPES:
+        raise HostNetworkError(
+            f"Unknown service '{sanitize(service, 60)}'. "
+            f"Valid services: {', '.join(sorted(_NIC_TYPES))}"
+        )
+
+    existing = {v.device for v in host.config.network.vnic or []}
+    if vmk not in existing:
+        raise HostNetworkError(
+            f"'{vmk}' not found on '{host_name}'. "
+            f"Present: {sanitize(str(sorted(existing)), 300) or 'none'}"
+        )
+
+    services = _vmk_services(host)
+    if services is None:
+        raise HostNetworkError(
+            "REFUSED: the host's service map cannot be read (virtualNicManager "
+            "unavailable), so the current selections cannot be verified and "
+            "this change cannot be made safely. Retry when the host is "
+            "reachable/healthy."
+        )
+    current = sorted(services.get(vmk, []))
+
+    if not enabled and service == "management" and "management" in current:
+        mgmt_vmks = [d for d, svcs in services.items() if "management" in svcs]
+        if len(mgmt_vmks) <= 1:
+            raise HostNetworkError(
+                f"REFUSED (no override): {vmk} is the ONLY management-enabled "
+                f"vmk on '{host_name}'. Untagging management severs the API "
+                "path this call rides on; after it succeeded, nothing could "
+                "reach the host to undo it."
+            )
+
+    change = {
+        "host": sanitize(host.name, 200),
+        "device": vmk,
+        "service": service,
+        "enabled": enabled,
+        "current_services": current,
+    }
+
+    if (service in current) == enabled:
+        return {
+            "action": "noop",
+            "unchanged": change,
+            "hint": f"{vmk} already has '{service}' "
+                    f"{'enabled' if enabled else 'disabled'}.",
+        }
+
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_set": change,
+            "hint": "Re-run with confirm=True to apply.",
+        }
+
+    mgr = host.configManager.virtualNicManager
+    if enabled:
+        mgr.SelectVnicForNicType(service, vmk)
+    else:
+        mgr.DeselectVnicForNicType(service, vmk)
+
+    after = _vmk_services(host)
+    return {
+        "action": "set",
+        "set": change,
+        "services_now": sorted(after.get(vmk, [])) if after is not None else None,
+    }
+
+
 # --- vmk_ping (esxcli over API, raw SOAP) ---------------------------------------
 #
 # The ManagedMethodExecuter types are internal VMODL that modern pyVmomi does


### PR DESCRIPTION
This closes the gap the v1.8.9 network suite left open on purpose:
`add_host_vmk` creates serviceless adapters, so the service tag (vmotion,
management, vsan, ...) stayed a UI-only step. During a host onboard this
week (M6 blades rolling into a vSphere 9 cluster), the vMotion vmk came up
correctly via MCP but sat untagged until a human clicked the box - the
full-host verify caught it. `set_vmk_service(host, vmk, service, enabled)`
finishes the story.

Design, following the suite's existing conventions:

- `Select/DeselectVnicForNicType` via the host's `virtualNicManager` -
  the same manager `list_host_vmks` already reads its `services` field
  from, so the write and its verify pair share one source of truth.
- Service names validated against a static NicType allowlist so typos
  fail loudly at validation (the enum value is `vSphereProvisioning`,
  not `provisioning` - an easy one to guess wrong).
- Preview/confirm gated like the other writes; idempotent - re-applying
  the current state returns a noop and never writes.
- FAIL CLOSED: an unreadable service map refuses both directions
  (idempotence and the guard below both need verified current state).
- ABSOLUTE, no override: disabling `management` on the host's only
  management-enabled vmk is refused - same class as the remove_host_vmk
  guard, the call rides the interface it would untag.

Tests: 7 new (validation, unreadable-map refusal both directions, the
absolute guard, second-mgmt-vmk allowed, noop, preview-never-writes,
enable/disable roundtrip). Live-verified on a vSphere 9.1 cluster:
scratch vmk on a TEP portgroup -> tagged vmotion -> verified via
list_host_vmks -> noop probe -> untagged -> guard probe on the real
mgmt vmk REFUSED -> scratch removed, baseline byte-identical.

Post-merge note: the UAA fork rebases its connection layer
(multi-vCenter routing, session eviction, env cred overrides) on top, as
with v1.8.9 - no fork-specific code in this branch.