### PR TITLE
feat: DRS rule suite - list/create/delete/enable-disable VM-VM rules

### DIFF
--- a/tests/test_drs_rules.py
+++ b/tests/test_drs_rules.py
@@ -1,0 +1,217 @@
+"""DRS rule ops: listing projections, exact-name matching, preview/confirm
+gates, idempotent noops, VM-VM-only guards, and spec application shapes."""
+import types
+
+import pytest
+from pyVmomi import vim
+
+from vmware_aiops.ops import cluster_mgmt as cm
+from vmware_aiops.ops.cluster_mgmt import (
+    ClusterError,
+    create_drs_rule,
+    delete_drs_rule,
+    list_drs_rules,
+    set_drs_rule_enabled,
+)
+
+VM_NAMES = {"vm-101": "cppm1", "vm-102": "amm-2"}
+
+
+def _vm_ref(mo_id):
+    return vim.VirtualMachine(mo_id)
+
+
+def _anti_rule(key=42, name="Aruba_Wirless_Servers", enabled=True):
+    return vim.cluster.AntiAffinityRuleSpec(
+        key=key, name=name, enabled=enabled,
+        vm=[_vm_ref("vm-101"), _vm_ref("vm-102")],
+    )
+
+
+def _vmhost_rule(key=77, name="oracle-must-run"):
+    return vim.cluster.VmHostRuleInfo(
+        key=key, name=name, enabled=True, mandatory=True,
+        vmGroupName="oracle-vms", affineHostGroupName="licensed-hosts",
+    )
+
+
+class FakeCluster:
+    """Cluster whose ReconfigureComputeResource_Task applies rulesSpec ops."""
+
+    def __init__(self, rules):
+        self.name = "ANC-UCS-PROD"
+        self._rules = list(rules)
+        self.applied_specs = []
+        self._next_key = 1000
+
+    @property
+    def configurationEx(self):  # noqa: N802 - pyVmomi property name
+        return types.SimpleNamespace(rule=list(self._rules))
+
+    def ReconfigureComputeResource_Task(self, spec, modify):  # noqa: N802
+        assert modify is True
+        self.applied_specs.append(spec)
+        for rs in spec.rulesSpec:
+            if rs.operation == "edit":
+                self._rules = [
+                    rs.info if r.key == rs.info.key else r for r in self._rules
+                ]
+            elif rs.operation == "add":
+                rs.info.key = self._next_key
+                self._rules.append(rs.info)
+            elif rs.operation == "remove":
+                self._rules = [r for r in self._rules if r.key != rs.removeKey]
+        return object()  # task sentinel; _wait_for_task is patched out
+
+
+@pytest.fixture
+def env(monkeypatch):
+    cluster = FakeCluster([_anti_rule(), _vmhost_rule()])
+    monkeypatch.setattr(cm, "find_cluster_by_name",
+                        lambda si, n: cluster if n == cluster.name else None)
+    monkeypatch.setattr(cm, "_wait_for_task", lambda task: None)
+    monkeypatch.setattr(cm, "_vm_name", lambda vm: VM_NAMES[vm._moId])
+    return types.SimpleNamespace(cluster=cluster, si=object())
+
+
+# --- list -------------------------------------------------------------------
+
+def test_list_projects_both_rule_shapes(env):
+    out = list_drs_rules(env.si, "ANC-UCS-PROD")
+    assert out["count"] == 2
+    anti = next(r for r in out["rules"] if r["type"] == "antiAffinity")
+    assert anti["name"] == "Aruba_Wirless_Servers"
+    assert anti["enabled"] is True
+    assert anti["vms"] == ["amm-2", "cppm1"]
+    vmhost = next(r for r in out["rules"] if r["type"] == "vmHost")
+    assert vmhost["mandatory"] is True
+    assert vmhost["affine_host_group"] == "licensed-hosts"
+    assert "vms" not in vmhost
+
+
+def test_unknown_cluster_and_rule_teach(env):
+    with pytest.raises(cm.ClusterNotFoundError):
+        list_drs_rules(env.si, "nope")
+    with pytest.raises(ClusterError, match="Existing rules"):
+        set_drs_rule_enabled(env.si, "ANC-UCS-PROD", "nope-rule", False)
+
+
+def test_ambiguous_rule_name_refuses(env):
+    env.cluster._rules.append(_anti_rule(key=43))  # duplicate name
+    with pytest.raises(ClusterError, match="ambiguous"):
+        set_drs_rule_enabled(env.si, "ANC-UCS-PROD", "Aruba_Wirless_Servers",
+                             False, confirm=True)
+    assert env.cluster.applied_specs == []
+
+
+# --- enable/disable ----------------------------------------------------------
+
+def test_set_enabled_noop_and_preview_never_write(env):
+    out = set_drs_rule_enabled(env.si, "ANC-UCS-PROD",
+                               "Aruba_Wirless_Servers", True, confirm=True)
+    assert out["action"] == "noop"
+    out = set_drs_rule_enabled(env.si, "ANC-UCS-PROD",
+                               "Aruba_Wirless_Servers", False)
+    assert out["action"] == "preview"
+    assert out["would_set"]["enabled"] is False
+    assert env.cluster.applied_specs == []
+
+
+def test_set_enabled_confirm_roundtrip(env):
+    out = set_drs_rule_enabled(env.si, "ANC-UCS-PROD",
+                               "Aruba_Wirless_Servers", False, confirm=True)
+    assert out["action"] == "set"
+    assert out["rule_now"]["enabled"] is False
+    out = set_drs_rule_enabled(env.si, "ANC-UCS-PROD",
+                               "Aruba_Wirless_Servers", True, confirm=True)
+    assert out["rule_now"]["enabled"] is True
+    ops = [s.rulesSpec[0].operation for s in env.cluster.applied_specs]
+    assert ops == ["edit", "edit"]
+
+
+# --- create -------------------------------------------------------------------
+
+def _patch_resolve(monkeypatch, refs):
+    monkeypatch.setattr(cm, "_resolve_rule_vms", lambda si, c, names: refs)
+
+
+def test_create_validates_type_name_and_members(env, monkeypatch):
+    with pytest.raises(ClusterError, match="rule_type"):
+        create_drs_rule(env.si, "ANC-UCS-PROD", "r", "vmHost",
+                        ["a", "b"], confirm=True)
+    with pytest.raises(ClusterError, match="already exists"):
+        create_drs_rule(env.si, "ANC-UCS-PROD", "Aruba_Wirless_Servers",
+                        "antiAffinity", ["a", "b"], confirm=True)
+    with pytest.raises(ClusterError, match="at least 2 distinct"):
+        create_drs_rule(env.si, "ANC-UCS-PROD", "r", "antiAffinity",
+                        ["a", "a"], confirm=True)
+    assert env.cluster.applied_specs == []
+
+
+def test_resolve_rule_vms_membership_guard(env, monkeypatch):
+    other_cluster = object()
+    vms = {
+        "in": types.SimpleNamespace(
+            resourcePool=types.SimpleNamespace(owner=env.cluster)),
+        "outside": types.SimpleNamespace(
+            resourcePool=types.SimpleNamespace(owner=other_cluster)),
+        "template": types.SimpleNamespace(resourcePool=None),
+    }
+    monkeypatch.setattr(cm, "find_vm_by_name", lambda si, n: vms.get(n))
+    with pytest.raises(ClusterError, match="not found"):
+        cm._resolve_rule_vms(env.si, env.cluster, ["missing"])
+    with pytest.raises(ClusterError, match="not in cluster"):
+        cm._resolve_rule_vms(env.si, env.cluster, ["outside"])
+    with pytest.raises(ClusterError, match="not in cluster"):
+        cm._resolve_rule_vms(env.si, env.cluster, ["template"])
+    assert cm._resolve_rule_vms(env.si, env.cluster, ["in"]) == [vms["in"]]
+
+
+def test_create_preview_then_confirm(env, monkeypatch):
+    _patch_resolve(monkeypatch, [_vm_ref("vm-101"), _vm_ref("vm-102")])
+    out = create_drs_rule(env.si, "ANC-UCS-PROD", "keep-apart",
+                          "antiAffinity", ["cppm1", "amm-2"])
+    assert out["action"] == "preview"
+    assert out["would_create"]["vms"] == ["cppm1", "amm-2"]
+    assert env.cluster.applied_specs == []
+
+    out = create_drs_rule(env.si, "ANC-UCS-PROD", "keep-apart",
+                          "antiAffinity", ["cppm1", "amm-2"], confirm=True)
+    assert out["action"] == "created"
+    assert out["created"]["type"] == "antiAffinity"
+    assert out["created"]["key"] == 1000
+    spec = env.cluster.applied_specs[-1].rulesSpec[0]
+    assert spec.operation == "add"
+    assert isinstance(spec.info, vim.cluster.AntiAffinityRuleSpec)
+    assert spec.info.userCreated is True
+
+
+def test_create_affinity_type_maps(env, monkeypatch):
+    _patch_resolve(monkeypatch, [_vm_ref("vm-101"), _vm_ref("vm-102")])
+    out = create_drs_rule(env.si, "ANC-UCS-PROD", "keep-together",
+                          "affinity", ["cppm1", "amm-2"], confirm=True)
+    assert out["created"]["type"] == "affinity"
+
+
+# --- delete -------------------------------------------------------------------
+
+def test_delete_refuses_vmhost_rules(env):
+    with pytest.raises(ClusterError, match="REFUSED.*vmHost"):
+        delete_drs_rule(env.si, "ANC-UCS-PROD", "oracle-must-run", confirm=True)
+    assert env.cluster.applied_specs == []
+
+
+def test_delete_preview_records_definition_then_confirm(env):
+    out = delete_drs_rule(env.si, "ANC-UCS-PROD", "Aruba_Wirless_Servers")
+    assert out["action"] == "preview"
+    assert out["would_delete"]["rule"]["vms"] == ["amm-2", "cppm1"]
+    assert env.cluster.applied_specs == []
+
+    out = delete_drs_rule(env.si, "ANC-UCS-PROD", "Aruba_Wirless_Servers",
+                          confirm=True)
+    assert out["action"] == "deleted"
+    assert out["deleted"]["rule"]["key"] == 42
+    spec = env.cluster.applied_specs[-1].rulesSpec[0]
+    assert spec.operation == "remove"
+    assert spec.removeKey == 42
+    assert list_drs_rules(env.si, "ANC-UCS-PROD")["count"] == 1

--- a/vmware_aiops/mcp_server/tools/cluster.py
+++ b/vmware_aiops/mcp_server/tools/cluster.py
@@ -164,3 +164,133 @@ def cluster_info(name: str, target: Optional[str] = None) -> dict:
     from vmware_aiops.ops.cluster_mgmt import get_cluster_info
     si = _get_connection(target)
     return get_cluster_info(si, name)
+
+
+@mcp.tool(annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+@vmware_tool(risk_level="low")
+@tool_errors("dict")
+def list_drs_rules(cluster: str, target: Optional[str] = None) -> dict:
+    """[READ] List a cluster's DRS rules: VM-VM affinity/anti-affinity and VM-Host.
+
+    Per rule: key, name, type (affinity / antiAffinity / vmHost), enabled,
+    mandatory, and the member VM names (VM-VM) or group names (VM-Host).
+    The verify pair for create/delete/set_drs_rule_enabled.
+
+    Args:
+        cluster: Exact cluster name.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Dict with cluster, count, and rules sorted by name. Errors return a
+        dict with "error" + hint.
+    """
+    from vmware_aiops.ops.cluster_mgmt import list_drs_rules as _list
+    si = _get_connection(target)
+    return _list(si, cluster)
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+@vmware_tool(risk_level="medium")
+@tool_errors("dict")
+def set_drs_rule_enabled(
+    cluster: str,
+    rule_name: str,
+    enabled: bool,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Enable or disable an existing DRS rule - preview/confirm gated.
+
+    The day-2 toggle: anti-affinity rules often must be disabled while a
+    cluster is temporarily too small to satisfy them, then re-enabled when
+    hosts return. Idempotent - matching state returns a noop, no write.
+    Names are matched exactly; ambiguous names refuse. Audited.
+
+    Args:
+        cluster: Exact cluster name.
+        rule_name: Exact rule name (see list_drs_rules).
+        enabled: True enables the rule; False disables it.
+        confirm: False previews; True applies.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview"), noop dict (action="noop"), or
+        result dict (action="set", rule_now). Errors return "error" + hint.
+    """
+    from vmware_aiops.ops.cluster_mgmt import set_drs_rule_enabled as _set
+    si = _get_connection(target)
+    return _set(si, cluster, rule_name=rule_name, enabled=enabled, confirm=confirm)
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True})
+@vmware_tool(risk_level="medium")
+@tool_errors("dict")
+def create_drs_rule(
+    cluster: str,
+    rule_name: str,
+    rule_type: str,
+    vm_names: list[str],
+    enabled: bool = True,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Create a VM-VM DRS rule (affinity or anti-affinity) - preview/confirm gated.
+
+    rule_type "affinity" keeps the listed VMs together; "antiAffinity"
+    keeps them apart (e.g. redundant appliance pairs on separate hosts).
+    Requires >=2 distinct VMs, all members of the cluster. VM-Host rules
+    hang off cluster VM/host groups and are not created here. Verify with
+    list_drs_rules. Audited.
+
+    Args:
+        cluster: Exact cluster name.
+        rule_name: Name for the new rule; must be unique on the cluster.
+        rule_type: "affinity" or "antiAffinity".
+        vm_names: VM names the rule governs (>=2, all in the cluster).
+        enabled: Create the rule enabled (default) or disabled.
+        confirm: False previews; True creates.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview", would_create) or result dict
+        (action="created", created incl. the assigned key). Errors return
+        a dict with "error" + hint.
+    """
+    from vmware_aiops.ops.cluster_mgmt import create_drs_rule as _create
+    si = _get_connection(target)
+    return _create(
+        si, cluster, rule_name=rule_name, rule_type=rule_type,
+        vm_names=vm_names, enabled=enabled, confirm=confirm,
+    )
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True})
+@vmware_tool(risk_level="high")
+@tool_errors("dict")
+def delete_drs_rule(
+    cluster: str,
+    rule_name: str,
+    confirm: bool = False,
+    target: Optional[str] = None,
+) -> dict:
+    """[WRITE] Delete a VM-VM DRS rule - confirm-gated, guarded.
+
+    REFUSES non-VM-VM rules: VM-Host rules can carry licensing/compliance
+    placement constraints (must-run-on licensed hosts) and hang off cluster
+    groups - manage those in the vSphere UI. The preview and result both
+    record the full rule definition so a mistaken delete can be recreated
+    from the audit trail. Audited.
+
+    Args:
+        cluster: Exact cluster name.
+        rule_name: Exact rule name (see list_drs_rules).
+        confirm: False previews; True deletes.
+        target: vCenter target name from config.yaml; omit to use the default target.
+
+    Returns:
+        Preview dict (action="preview", would_delete) or result dict
+        (action="deleted", deleted). Errors return a dict with "error" + hint.
+    """
+    from vmware_aiops.ops.cluster_mgmt import delete_drs_rule as _delete
+    si = _get_connection(target)
+    return _delete(si, cluster, rule_name=rule_name, confirm=confirm)

--- a/vmware_aiops/ops/cluster_mgmt.py
+++ b/vmware_aiops/ops/cluster_mgmt.py
@@ -12,6 +12,7 @@ from vmware_aiops.ops.inventory import (
     _collect,
     find_cluster_by_name,
     find_host_by_name,
+    find_vm_by_name,
     resolve_datacenter,
 )
 from vmware_aiops.ops.vm_lifecycle import _wait_for_task
@@ -303,3 +304,249 @@ def configure_cluster(
     task = cluster.ReconfigureComputeResource_Task(spec=spec, modify=True)
     _wait_for_task(task)
     return f"Cluster '{cluster_name}' reconfigured: {', '.join(changes)}."
+
+
+# ─── DRS affinity / anti-affinity rules ──────────────────────────────────────
+
+_VM_VM_RULE_CLASSES = {
+    vim.cluster.AffinityRuleSpec: "affinity",
+    vim.cluster.AntiAffinityRuleSpec: "antiAffinity",
+}
+
+_CREATABLE_RULE_TYPES = {
+    "affinity": vim.cluster.AffinityRuleSpec,
+    "antiAffinity": vim.cluster.AntiAffinityRuleSpec,
+}
+
+
+def _rule_type_label(rule) -> str:
+    """Human label for a rule's concrete type. VM-VM types get stable names."""
+    for cls, label in _VM_VM_RULE_CLASSES.items():
+        if isinstance(rule, cls):
+            return label
+    if isinstance(rule, vim.cluster.VmHostRuleInfo):
+        return "vmHost"
+    return type(rule).__name__.rsplit(".", 1)[-1]
+
+
+def _vm_name(vm) -> str:
+    """Server round-trip for a VM ref's name (seam for tests)."""
+    return vm.name
+
+
+def _rule_summary(rule) -> dict:
+    """Projection of one rule. VM names are resolved lazily - rule counts are
+    small (units, not hundreds), so the per-VM read is acceptable here."""
+    out = {
+        "key": rule.key,
+        "name": sanitize(rule.name, 200),
+        "type": _rule_type_label(rule),
+        "enabled": bool(rule.enabled),
+        "mandatory": bool(rule.mandatory) if rule.mandatory is not None else False,
+    }
+    if isinstance(rule, tuple(_VM_VM_RULE_CLASSES)):
+        out["vms"] = sorted(sanitize(_vm_name(vm), 200) for vm in rule.vm or [])
+    elif isinstance(rule, vim.cluster.VmHostRuleInfo):
+        out["vm_group"] = sanitize(rule.vmGroupName or "", 200)
+        out["affine_host_group"] = sanitize(rule.affineHostGroupName or "", 200)
+        out["anti_affine_host_group"] = sanitize(rule.antiAffineHostGroupName or "", 200)
+    return out
+
+
+def _cluster_rules(cluster) -> list:
+    cfg = cluster.configurationEx
+    return list(cfg.rule or []) if cfg is not None else []
+
+
+def _require_rule(cluster, rule_name: str):
+    """Find a rule by exact name; refuse ambiguity, teach on miss."""
+    matches = [r for r in _cluster_rules(cluster) if r.name == rule_name]
+    if not matches:
+        names = sorted(sanitize(r.name, 100) for r in _cluster_rules(cluster))
+        raise ClusterError(
+            f"No rule named '{sanitize(rule_name, 100)}' on cluster "
+            f"'{sanitize(cluster.name, 100)}'. Existing rules: "
+            f"{', '.join(names) or 'none'}. Names are matched exactly."
+        )
+    if len(matches) > 1:
+        raise ClusterError(
+            f"Rule name '{sanitize(rule_name, 100)}' is ambiguous - "
+            f"{len(matches)} rules share it (keys "
+            f"{sorted(r.key for r in matches)}). Rename one in the UI first."
+        )
+    return matches[0]
+
+
+def _apply_rule_spec(cluster, operation: str, rule=None, remove_key=None) -> None:
+    rule_spec = vim.cluster.RuleSpec(operation=operation)
+    if rule is not None:
+        rule_spec.info = rule
+    if remove_key is not None:
+        rule_spec.removeKey = remove_key
+    spec = vim.cluster.ConfigSpecEx(rulesSpec=[rule_spec])
+    task = cluster.ReconfigureComputeResource_Task(spec=spec, modify=True)
+    _wait_for_task(task)
+
+
+def list_drs_rules(si: ServiceInstance, cluster_name: str) -> dict:
+    """All DRS rules on a cluster (VM-VM affinity/anti-affinity, VM-Host)."""
+    cluster = _require_cluster(si, cluster_name)
+    rules = [_rule_summary(r) for r in _cluster_rules(cluster)]
+    return {
+        "cluster": sanitize(cluster.name, 200),
+        "count": len(rules),
+        "rules": sorted(rules, key=lambda r: r["name"]),
+    }
+
+
+def set_drs_rule_enabled(
+    si: ServiceInstance,
+    cluster_name: str,
+    rule_name: str,
+    enabled: bool,
+    confirm: bool = False,
+) -> dict:
+    """Flip an existing rule's enabled flag - confirm-gated, idempotent."""
+    cluster = _require_cluster(si, cluster_name)
+    rule = _require_rule(cluster, rule_name)
+    change = {
+        "cluster": sanitize(cluster.name, 200),
+        "rule": _rule_summary(rule),
+        "enabled": enabled,
+    }
+    if bool(rule.enabled) == enabled:
+        return {
+            "action": "noop",
+            "unchanged": change,
+            "hint": f"Rule '{rule.name}' is already "
+                    f"{'enabled' if enabled else 'disabled'}.",
+        }
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_set": change,
+            "hint": "Re-run with confirm=True to apply.",
+        }
+    rule.enabled = enabled
+    _apply_rule_spec(cluster, "edit", rule=rule)
+    now = _require_rule(cluster, rule_name)
+    return {"action": "set", "set": change, "rule_now": _rule_summary(now)}
+
+
+def _resolve_rule_vms(si: ServiceInstance, cluster, vm_names: list[str]) -> list:
+    """Resolve rule-member names to VM refs, requiring cluster membership."""
+    vms = []
+    for name in vm_names:
+        vm = find_vm_by_name(si, name)
+        if vm is None:
+            raise ClusterError(f"VM '{sanitize(name, 200)}' not found.")
+        pool = vm.resourcePool
+        if pool is None or pool.owner != cluster:
+            raise ClusterError(
+                f"VM '{sanitize(name, 200)}' is not in cluster "
+                f"'{sanitize(cluster.name, 100)}' (or is a template) - "
+                "rule members must belong to the rule's cluster."
+            )
+        vms.append(vm)
+    return vms
+
+
+def create_drs_rule(
+    si: ServiceInstance,
+    cluster_name: str,
+    rule_name: str,
+    rule_type: str,
+    vm_names: list[str],
+    enabled: bool = True,
+    confirm: bool = False,
+) -> dict:
+    """Create a VM-VM affinity or anti-affinity rule - confirm-gated.
+
+    VM-Host rules are out of scope (they hang off cluster VM/host groups -
+    a separate management surface).
+    """
+    cluster = _require_cluster(si, cluster_name)
+
+    if rule_type not in _CREATABLE_RULE_TYPES:
+        raise ClusterError(
+            f"rule_type must be one of {sorted(_CREATABLE_RULE_TYPES)} "
+            f"(got '{sanitize(rule_type, 60)}'). VM-Host rules are managed "
+            "via cluster groups and are not created here."
+        )
+    if any(r.name == rule_name for r in _cluster_rules(cluster)):
+        raise ClusterError(
+            f"A rule named '{sanitize(rule_name, 100)}' already exists on "
+            f"'{sanitize(cluster.name, 100)}'."
+        )
+    unique_vms = list(dict.fromkeys(vm_names or []))
+    if len(unique_vms) < 2:
+        raise ClusterError(
+            "A VM-VM rule needs at least 2 distinct VMs "
+            f"(got {len(unique_vms)})."
+        )
+
+    vms = _resolve_rule_vms(si, cluster, unique_vms)
+
+    would = {
+        "cluster": sanitize(cluster.name, 200),
+        "name": sanitize(rule_name, 200),
+        "type": rule_type,
+        "enabled": enabled,
+        "vms": [sanitize(n, 200) for n in unique_vms],
+    }
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_create": would,
+            "hint": "Re-run with confirm=True to create.",
+        }
+
+    info = _CREATABLE_RULE_TYPES[rule_type](
+        name=rule_name, enabled=enabled, userCreated=True, vm=vms
+    )
+    _apply_rule_spec(cluster, "add", rule=info)
+    now = _require_rule(cluster, rule_name)
+    return {"action": "created", "created": _rule_summary(now)}
+
+
+def delete_drs_rule(
+    si: ServiceInstance,
+    cluster_name: str,
+    rule_name: str,
+    confirm: bool = False,
+) -> dict:
+    """Delete a VM-VM affinity/anti-affinity rule - confirm-gated.
+
+    REFUSES non-VM-VM rules (VM-Host rules can carry licensing/compliance
+    placement constraints and hang off cluster groups - manage those in the
+    UI). The preview and the result both record the full rule definition,
+    so a mistaken delete can be recreated from the audit trail.
+    """
+    cluster = _require_cluster(si, cluster_name)
+    rule = _require_rule(cluster, rule_name)
+    if not isinstance(rule, tuple(_VM_VM_RULE_CLASSES)):
+        raise ClusterError(
+            f"REFUSED: '{sanitize(rule_name, 100)}' is a "
+            f"{_rule_type_label(rule)} rule, not VM-VM. VM-Host and other "
+            "rule types can carry licensing/compliance placement constraints "
+            "- manage them in the vSphere UI."
+        )
+    doomed = {
+        "cluster": sanitize(cluster.name, 200),
+        "rule": _rule_summary(rule),
+    }
+    if not confirm:
+        return {
+            "action": "preview",
+            "would_delete": doomed,
+            "hint": "Re-run with confirm=True to delete. The definition "
+                    "above is what you would recreate it from.",
+        }
+    _apply_rule_spec(cluster, "remove", remove_key=rule.key)
+    remaining = [r.name for r in _cluster_rules(cluster) if r.name == rule_name]
+    if remaining:
+        raise ClusterError(
+            f"Delete task completed but '{sanitize(rule_name, 100)}' is "
+            "still present - inspect the cluster in the UI."
+        )
+    return {"action": "deleted", "deleted": doomed}


### PR DESCRIPTION
Day-2 cluster ops: `cluster_configure` toggles cluster-wide DRS, but
individual rules had no surface. The motivating case: a 4-VM
anti-affinity rule that had to be disabled in the UI while a cluster was
temporarily too small to satisfy it during a host-by-host hardware roll,
then re-enabled when hosts returned - three UI trips and counting, one
per blade. `set_drs_rule_enabled` alone retires that class of trip; the
rest of the suite covers the neighboring ops the first tool makes
people ask for.

Four tools:

- `list_drs_rules` [READ, low] - VM-VM affinity/anti-affinity and
  VM-Host rules: key, name, type, enabled, mandatory, member VM names
  (VM-VM) or group names (VM-Host). The verify pair for the writes.
- `set_drs_rule_enabled` [WRITE, medium] - flip an existing rule's
  enabled flag. Idempotent (matching state = noop, no write).
- `create_drs_rule` [WRITE, medium] - VM-VM affinity or anti-affinity,
  >=2 distinct VMs, each validated as a member of the rule's cluster.
- `delete_drs_rule` [WRITE, high] - VM-VM only; REFUSES VM-Host and
  other rule types (they can carry licensing/compliance placement
  constraints and hang off cluster groups). Preview and result both
  record the full rule definition, so a mistaken delete can be
  recreated from the audit trail.

Design notes:

- Rules ride `ClusterConfigSpecEx.rulesSpec` via
  `ReconfigureComputeResource_Task(modify=True)` - the same call
  `configure_cluster` already uses.
- Exact-name matching; a duplicated rule name refuses as ambiguous
  rather than guessing (vCenter allows duplicates; keys disambiguate
  but names are what operators know).
- VM-Host rules (and their VM/host groups) are deliberately out of
  scope - group management is its own surface and nothing demanded it
  yet. The list tool still shows them so operators see the whole
  picture.

Tests: 11 new (projection of both rule shapes, exact/ambiguous name
handling, noop + preview never write, edit/add/remove spec shapes,
membership guard incl. templates, vmHost delete refusal). Live-verified
on a production vSphere 9.1 cluster: scratch anti-affinity rule created
disabled on two already-separated VMs -> enabled -> noop probe ->
disabled -> deleted -> rule list byte-identical to baseline, real rules
untouched.

Post-merge note: the UAA fork rebases its connection layer
(multi-vCenter routing, session eviction, env cred overrides) on top, as
with v1.8.9 - no fork-specific code in this branch.