### PR TITLE
fix: pin UTF-8 on all text-mode file I/O

### DIFF
--- a/tests/eval/capability/_scoring.py
+++ b/tests/eval/capability/_scoring.py
@@ -132,13 +132,13 @@ class ScoreBoard:
             ),
             "scores": merged,
         }
-        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def previous_scores(path: Path = SCORES_PATH) -> dict[str, Any]:
     """Load the last recorded run, or ``{}`` on a first run / unreadable file."""
     try:
-        return json.loads(path.read_text()).get("scores", {})
+        return json.loads(path.read_text(encoding="utf-8")).get("scores", {})
     except (OSError, ValueError):
         return {}
 

--- a/tests/eval/regression/test_capability_grader.py
+++ b/tests/eval/regression/test_capability_grader.py
@@ -182,7 +182,8 @@ def test_an_error_returned_via_a_local_is_still_seen(tmp_path):
         "        pass\n"
         "    except Exception as exc:\n"
         "        payload = {'error': str(exc), 'hint': _HINT}\n"
-        "        return payload\n"
+        "        return payload\n",
+        encoding="utf-8",
     )
     sites = list(_error_returns_in_server(server_dir=tmp_path, module=None))
 
@@ -218,7 +219,7 @@ def test_a_partial_run_does_not_erase_metrics_it_did_not_measure(tmp_path):
     partial.add(Score(name="alpha", value=2, maximum=2))
     partial.write(path)
 
-    scores = json.loads(path.read_text())["scores"]
+    scores = json.loads(path.read_text(encoding="utf-8"))["scores"]
     assert set(scores) == {"alpha", "beta"}, "a partial run deleted a metric"
     assert scores["alpha"]["value"] == 2, "the fresh measurement must win"
     assert not scores["alpha"].get("stale"), "a freshly measured metric is not stale"
@@ -237,7 +238,7 @@ def test_an_empty_run_leaves_the_baseline_alone(tmp_path):
     seeded.write(path)
 
     ScoreBoard().write(path)
-    assert set(json.loads(path.read_text())["scores"]) == {"alpha"}
+    assert set(json.loads(path.read_text(encoding="utf-8"))["scores"]) == {"alpha"}
 
 
 def test_credits_a_real_subcommand_under_a_group():

--- a/tests/eval/regression/test_cluster_health_summary_delegation.py
+++ b/tests/eval/regression/test_cluster_health_summary_delegation.py
@@ -164,7 +164,7 @@ def test_cli_investigate_vm_delegates(tmp_path) -> None:
         assert "web-01" in term.output
         html = CliRunner().invoke(app, ["investigate", "vm", "web-01", "--html-path", str(out)])
         assert html.exit_code == 0, html.output
-    assert out.read_text().startswith("<!doctype html>")
+    assert out.read_text(encoding="utf-8").startswith("<!doctype html>")
 
 
 def test_cli_attention_delegates(tmp_path) -> None:
@@ -224,4 +224,4 @@ def test_cli_summary_terminal_and_html(tmp_path) -> None:
         html = CliRunner().invoke(app, ["summary", "--html-path", str(out)])
         assert html.exit_code == 0, html.output
     assert out.exists()
-    assert out.read_text().startswith("<!doctype html>")
+    assert out.read_text(encoding="utf-8").startswith("<!doctype html>")

--- a/tests/eval/regression/test_code_review_fixes.py
+++ b/tests/eval/regression/test_code_review_fixes.py
@@ -96,7 +96,7 @@ def test_no_tool_module_passes_a_hardcoded_safe_error_label() -> None:
     tools_dir = _REPO / "vmware_aiops" / "mcp_server" / "tools"
     offenders = []
     for path in sorted(tools_dir.glob("*.py")):
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if (
                 isinstance(node, ast.Call)
@@ -278,7 +278,7 @@ def test_find_triggered_alarm_destroys_container_exactly_once() -> None:
     ],
 )
 def test_urlopen_calls_have_timeout(rel_path: str) -> None:
-    src = (_REPO / rel_path).read_text()
+    src = (_REPO / rel_path).read_text(encoding="utf-8")
     tree = ast.parse(src)
     found = 0
     for node in ast.walk(tree):

--- a/tests/eval/regression/test_list_plans_is_non_destructive.py
+++ b/tests/eval/regression/test_list_plans_is_non_destructive.py
@@ -45,7 +45,8 @@ def _write_plan(directory, plan_id: str, *, age_seconds: float, status: str = "f
                 "status": status,
                 "summary": {"total_steps": 3, "vms_affected": 2},
             }
-        )
+        ),
+        encoding="utf-8",
     )
     stamp = time.time() - age_seconds
     import os

--- a/tests/eval/regression/test_release_blockers.py
+++ b/tests/eval/regression/test_release_blockers.py
@@ -41,7 +41,7 @@ def test_pyproject_ships_the_server_inside_the_package() -> None:
     The server now lives inside the package namespace, where the name is ours.
     """
     pyproject = REPO_ROOT / "pyproject.toml"
-    data = tomllib.loads(pyproject.read_text())
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
     packages = (
         data.get("tool", {}).get("hatch", {})
         .get("build", {}).get("targets", {})
@@ -127,7 +127,7 @@ def test_runtime_names_have_imports() -> None:
     pkg_dir = REPO_ROOT / PKG_NAME
     failures: list[str] = []
     for py in _walk_python_files(pkg_dir):
-        src = py.read_text()
+        src = py.read_text(encoding="utf-8")
         try:
             tree = ast.parse(src)
         except SyntaxError:

--- a/tests/eval/regression/test_result_envelope.py
+++ b/tests/eval/regression/test_result_envelope.py
@@ -87,7 +87,8 @@ def _stub_plans(monkeypatch, tmp_path: Path, n: int) -> None:
                     "status": "pending",
                     "summary": {"total_steps": 1, "vms_affected": ["vm-1"]},
                 }
-            )
+            ),
+            encoding="utf-8",
         )
     monkeypatch.setattr(planner, "_PLANS_DIR", tmp_path)
     monkeypatch.setattr(planner, "_cleanup_stale", lambda: None)
@@ -103,7 +104,7 @@ def _stub_ttl_store(monkeypatch, tmp_path: Path, vm_names: list[str]) -> None:
         for name in vm_names
     }
     store_file = tmp_path / "ttl.json"
-    store_file.write_text(json.dumps(store))
+    store_file.write_text(json.dumps(store), encoding="utf-8")
     monkeypatch.setattr(ttl, "_TTL_FILE", store_file)
 
 

--- a/tests/eval/regression/test_v1_5_25_blockers.py
+++ b/tests/eval/regression/test_v1_5_25_blockers.py
@@ -193,7 +193,7 @@ def test_mcp_server_uses_optional_not_pep604() -> None:
 
     bad = []
     for path in files:
-        src = path.read_text()
+        src = path.read_text(encoding="utf-8")
         # exclude comments / docstrings — look only at type annotations
         for i, line in enumerate(src.splitlines(), 1):
             stripped = line.strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,7 +33,7 @@ scanner:
 notify:
   log_file: /tmp/test-scan.log
   webhook_url: https://hooks.example.com/test
-""")
+""", encoding="utf-8")
     return config
 
 

--- a/tests/test_init_and_onboarding.py
+++ b/tests/test_init_and_onboarding.py
@@ -42,7 +42,7 @@ def test_init_writes_grep_safe_env(_wizard_env: Path, monkeypatch: pytest.Monkey
     )
     assert init_wizard.run_init(skip_test=True) == 0
 
-    env_text = (_wizard_env / ".env").read_text()
+    env_text = (_wizard_env / ".env").read_text(encoding="utf-8")
     assert "VMWARE_LAB_VC_PASSWORD=b64:" in env_text
     assert "S3cr3t!pw" not in env_text  # never plaintext on disk
     assert (_wizard_env / ".env").stat().st_mode & 0o777 == 0o600
@@ -62,7 +62,7 @@ def _init_registered() -> bool:
 def test_doctor_init_reference_is_backed_by_real_command():
     from vmware_aiops import doctor
 
-    src = Path(doctor.__file__).read_text()
+    src = Path(doctor.__file__).read_text(encoding="utf-8")
     if "vmware-aiops init" in src:
         assert _init_registered(), "doctor recommends init but no such command is registered"
 

--- a/tests/test_no_destructive_ops.py
+++ b/tests/test_no_destructive_ops.py
@@ -33,7 +33,7 @@ DESTRUCTIVE_CLI_COMMANDS: list[tuple[str, str]] = [
 
 
 def _has_confirm_guard(file_path: Path, func_name: str) -> bool:
-    tree = ast.parse(file_path.read_text())
+    tree = ast.parse(file_path.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
             source = ast.dump(node)

--- a/vmware_aiops/cli/mcp_config.py
+++ b/vmware_aiops/cli/mcp_config.py
@@ -79,7 +79,7 @@ def mcp_config_generate(
         console.print(f"[red]Template file not found: {template_file}[/]")
         raise typer.Exit(1)
 
-    content = template_file.read_text()
+    content = template_file.read_text(encoding="utf-8")
 
     # Replace placeholder with actual path if provided
     if install_path:
@@ -93,7 +93,7 @@ def mcp_config_generate(
             content = content.replace("/path/to/VMware-AIops", str(pkg_dir))
 
     if output:
-        output.write_text(content)
+        output.write_text(content, encoding="utf-8")
         console.print(f"[green]Config written to: {output}[/]")
     else:
         console.print(content)
@@ -153,7 +153,7 @@ def mcp_config_install(
         console.print(f"[red]Template file not found: {template_file}[/]")
         raise typer.Exit(1)
 
-    content = template_file.read_text()
+    content = template_file.read_text(encoding="utf-8")
     if install_path:
         abs_path = str(Path(install_path).resolve())
         content = content.replace("/path/to/VMware-AIops", abs_path)
@@ -184,26 +184,26 @@ def mcp_config_install(
     # For JSON configs: merge mcpServers entry if file exists
     if dest.suffix == ".json" and dest.exists():
         try:
-            existing = json.loads(dest.read_text())
+            existing = json.loads(dest.read_text(encoding="utf-8"))
             new_entry = json.loads(content)
             # Merge: support both {mcpServers: {...}} and flat formats
             if "mcpServers" in new_entry:
                 existing.setdefault("mcpServers", {}).update(new_entry["mcpServers"])
             else:
                 existing.update(new_entry)
-            dest.write_text(json.dumps(existing, indent=2) + "\n")
+            dest.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
             console.print(f"[green]✓ Merged vmware-aiops into: {dest}[/]")
         except json.JSONDecodeError as e:
             console.print(f"[red]Existing config is not valid JSON: {e}[/]")
             console.print("[yellow]Writing new config (backup original first).[/]")
-            dest.with_suffix(".bak").write_text(dest.read_text())
-            dest.write_text(content)
+            dest.with_suffix(".bak").write_text(dest.read_text(encoding="utf-8"), encoding="utf-8")
+            dest.write_text(content, encoding="utf-8")
             console.print(f"[green]✓ Written: {dest} (backup: {dest.with_suffix('.bak')})[/]")
         except OSError as e:
             console.print(f"[red]Failed to read/write config: {e}[/]")
             raise typer.Exit(1) from e
     else:
-        dest.write_text(content)
+        dest.write_text(content, encoding="utf-8")
         console.print(f"[green]✓ Written: {dest}[/]")
 
     console.print("\n[dim]Run 'vmware-aiops doctor' to verify your setup.[/]")

--- a/vmware_aiops/cli/scan.py
+++ b/vmware_aiops/cli/scan.py
@@ -66,7 +66,7 @@ def daemon_status() -> None:
     """Check scanner daemon status."""
     pid_file = CONFIG_DIR / "daemon.pid"
     if pid_file.exists():
-        pid = pid_file.read_text().strip()
+        pid = pid_file.read_text(encoding="utf-8").strip()
         console.print(f"[green]Daemon running (PID: {pid})[/]")
     else:
         console.print("[yellow]Daemon not running.[/]")
@@ -83,7 +83,7 @@ def daemon_stop() -> None:
         console.print("[yellow]Daemon not running.[/]")
         return
 
-    pid = int(pid_file.read_text().strip())
+    pid = int(pid_file.read_text(encoding="utf-8").strip())
     try:
         _os.kill(pid, signal.SIGTERM)
         console.print(f"[green]Daemon (PID: {pid}) stopped.[/]")

--- a/vmware_aiops/config.py
+++ b/vmware_aiops/config.py
@@ -253,7 +253,7 @@ def load_config(config_path: Path | None = None) -> AppConfig:
             f"to {CONFIG_FILE} and edit it."
         )
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         raw = yaml.safe_load(f) or {}
 
     if isinstance(raw, dict) and "read_only" in raw:

--- a/vmware_aiops/doctor.py
+++ b/vmware_aiops/doctor.py
@@ -66,7 +66,7 @@ def _check_targets() -> tuple[bool, str]:
         return False, "Config file missing — skipping target check"
     import yaml
 
-    with open(CONFIG_FILE) as f:
+    with open(CONFIG_FILE, encoding="utf-8") as f:
         raw = yaml.safe_load(f) or {}
     targets = raw.get("targets", [])
     if not targets:
@@ -80,7 +80,7 @@ def _check_connectivity() -> tuple[bool, str]:
         return False, "Config file missing — skipping connectivity check"
     import yaml
 
-    with open(CONFIG_FILE) as f:
+    with open(CONFIG_FILE, encoding="utf-8") as f:
         raw = yaml.safe_load(f) or {}
     targets = raw.get("targets", [])
     if not targets:
@@ -127,7 +127,7 @@ def _check_daemon() -> tuple[bool, str]:
     pid_file = CONFIG_DIR / "daemon.pid"
     if not pid_file.exists():
         return True, "Daemon not running (optional — needed for TTL auto-destroy)"
-    pid = pid_file.read_text().strip()
+    pid = pid_file.read_text(encoding="utf-8").strip()
     try:
         import os as _os
 
@@ -144,7 +144,7 @@ def _check_ttl_store() -> tuple[bool, str]:
     if not ttl_file.exists():
         return True, "TTL store empty (no VMs with TTL set)"
     try:
-        data = json.loads(ttl_file.read_text())
+        data = json.loads(ttl_file.read_text(encoding="utf-8"))
         count = len(data)
         return True, f"TTL store: {count} VM(s) registered"
     except json.JSONDecodeError:

--- a/vmware_aiops/init_wizard.py
+++ b/vmware_aiops/init_wizard.py
@@ -93,7 +93,7 @@ def run_init(force: bool = False, skip_test: bool = False) -> int:
         "scanner": {"enabled": True, "interval_minutes": 15, "severity_threshold": "warning"},
         "notify": {"webhook_url": ""},
     }
-    CONFIG_FILE.write_text(yaml.safe_dump(config, sort_keys=False))
+    CONFIG_FILE.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     env_key = _write_env(target["name"], password)
 
     console.print()

--- a/vmware_aiops/notify/audit.py
+++ b/vmware_aiops/notify/audit.py
@@ -62,7 +62,7 @@ class AuditLogger:
         }
 
         existed = self._path.exists()
-        with open(self._path, "a") as fh:
+        with open(self._path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
         if not existed:
             try:

--- a/vmware_aiops/notify/logger.py
+++ b/vmware_aiops/notify/logger.py
@@ -24,7 +24,7 @@ class ScanLogger:
         }
 
         # Append to JSONL file
-        with open(self._path, "a") as f:
+        with open(self._path, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
         # Also log to console

--- a/vmware_aiops/ops/datastore_browser.py
+++ b/vmware_aiops/ops/datastore_browser.py
@@ -182,7 +182,7 @@ def _load_registry() -> dict:
     """Load the local image registry from disk."""
     if not IMAGE_REGISTRY_FILE.exists():
         return {"images": [], "last_scan": None}
-    with open(IMAGE_REGISTRY_FILE) as f:
+    with open(IMAGE_REGISTRY_FILE, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -191,7 +191,7 @@ def _save_registry(registry: dict) -> None:
     from vmware_aiops._fsutil import secure_chmod_file, secure_mkdir
 
     secure_mkdir(CONFIG_DIR)
-    with open(IMAGE_REGISTRY_FILE, "w") as f:
+    with open(IMAGE_REGISTRY_FILE, "w", encoding="utf-8") as f:
         json.dump(registry, f, indent=2, ensure_ascii=False)
     secure_chmod_file(IMAGE_REGISTRY_FILE)
 

--- a/vmware_aiops/ops/guest_ops.py
+++ b/vmware_aiops/ops/guest_ops.py
@@ -233,7 +233,7 @@ def guest_exec_with_output(
 
     try:
         guest_download(si, vm_name, tmp_out, local_tmp, username, password)
-        with open(local_tmp, "r", errors="replace") as f:
+        with open(local_tmp, "r", encoding="utf-8", errors="replace") as f:
             stdout = f.read()
     except Exception as e:
         logger.warning("Could not retrieve output file from guest: %s", e)

--- a/vmware_aiops/ops/planner.py
+++ b/vmware_aiops/ops/planner.py
@@ -444,7 +444,7 @@ def create_plan(
 
     secure_mkdir(_PLANS_DIR)
     plan_path = _PLANS_DIR / f"{plan_id}.json"
-    plan_path.write_text(json.dumps(plan.to_dict(), indent=2, ensure_ascii=False))
+    plan_path.write_text(json.dumps(plan.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
     secure_chmod_file(plan_path)
     logger.info("Plan created: %s (%d steps)", plan_id, len(steps))
 
@@ -456,7 +456,7 @@ def load_plan(plan_id: str) -> dict | None:
     plan_path = _PLANS_DIR / f"{plan_id}.json"
     if not plan_path.exists():
         return None
-    return json.loads(plan_path.read_text())
+    return json.loads(plan_path.read_text(encoding="utf-8"))
 
 
 def save_plan(plan: dict) -> None:
@@ -464,7 +464,7 @@ def save_plan(plan: dict) -> None:
     from vmware_aiops._fsutil import secure_chmod_file
 
     plan_path = _PLANS_DIR / f"{plan['plan_id']}.json"
-    plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=False))
+    plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=False), encoding="utf-8")
     secure_chmod_file(plan_path)
 
 
@@ -490,7 +490,7 @@ def list_plans() -> dict:
     result: list[dict] = []
     for p in sorted(_PLANS_DIR.glob("plan-*.json")):
         try:
-            data = json.loads(p.read_text())
+            data = json.loads(p.read_text(encoding="utf-8"))
             result.append({
                 "plan_id": data["plan_id"],
                 "created_at": data["created_at"],

--- a/vmware_aiops/ops/ttl.py
+++ b/vmware_aiops/ops/ttl.py
@@ -40,7 +40,7 @@ def _load_ttl_store() -> dict[str, dict]:
     if not _TTL_FILE.exists():
         return {}
     try:
-        return json.loads(_TTL_FILE.read_text())
+        return json.loads(_TTL_FILE.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Failed to load TTL store: %s", e)
         return {}
@@ -51,7 +51,7 @@ def _save_ttl_store(store: dict[str, dict]) -> None:
     from vmware_aiops._fsutil import secure_chmod_file, secure_mkdir
 
     secure_mkdir(_TTL_FILE.parent)
-    _TTL_FILE.write_text(json.dumps(store, indent=2))
+    _TTL_FILE.write_text(json.dumps(store, indent=2), encoding="utf-8")
     secure_chmod_file(_TTL_FILE)
 
 

--- a/vmware_aiops/ops/vm_deploy.py
+++ b/vmware_aiops/ops/vm_deploy.py
@@ -495,7 +495,7 @@ def load_deploy_spec(spec_path: str) -> dict:
         ova: /path/to/image.ova       # Per-VM OVA override
     ```
     """
-    with open(spec_path) as f:
+    with open(spec_path, encoding="utf-8") as f:
         spec = yaml.safe_load(f)
 
     if not spec or "vms" not in spec:

--- a/vmware_aiops/scanner/scheduler.py
+++ b/vmware_aiops/scanner/scheduler.py
@@ -125,7 +125,7 @@ def start_scheduler(config_path: Path | None = None) -> None:
 
     # Write PID file
     PID_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PID_FILE.write_text(str(os.getpid()))
+    PID_FILE.write_text(str(os.getpid()), encoding="utf-8")
 
     scheduler = BlockingScheduler()
     scheduler.add_job(


### PR DESCRIPTION
The small follow-up you suggested on #35 - thanks for the offer!

**The problem:** with no explicit encoding, Python's text-mode file I/O uses the locale codepage - cp1252 on Windows. Ten files in the repo currently contain UTF-8 sequences that cp1252 cannot decode at all (emoji bytes landing on cp1252's five undefined codepoints), so any unpinned `read_text()` that touches one raises `UnicodeDecodeError`. At 5a66f56 that was 12 test failures on a Windows checkout (`test_no_destructive_ops.py` reading `cli/vm.py` and `cli/cluster.py`). Current main happens to pass only because no unpinned read lands on one of those ten files right now - any future emoji or arrow character flips it back.

The write side is the same bug from the other direction: an unpinned `write_text()` (init wizard config, plan store, `mcp_config` output) produces a locale-encoded file on Windows that breaks when read back as UTF-8, e.g. a config value with a non-ASCII character round-trips differently across machines.

**The fix:** `encoding="utf-8"` pinned on every text-mode `read_text` / `write_text` / `open` across source and tests (46 sites). Mechanical change only - no logic touched, binary-mode calls untouched.

**Verified:**
- Full suite on a Windows/cp1252 checkout: 419 passed; the only 2 failures are the pre-existing 0600-permission asserts, which fail identically on clean main there (Windows chmod semantics) and pass on Linux.
- Ruff with the repo config: violation counts identical to main - no new lint.
- Byte-level scan confirms the ten undecodable files are the full set; after this change no unpinned text I/O remains.